### PR TITLE
feat(inqacc): translate INQACC to Java

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/AccountDetails.java
+++ b/src/main/java/com/augment/cbsa/domain/AccountDetails.java
@@ -1,0 +1,48 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record AccountDetails(
+        String sortcode,
+        long customerNumber,
+        long accountNumber,
+        String accountType,
+        BigDecimal interestRate,
+        LocalDate opened,
+        BigDecimal overdraftLimit,
+        LocalDate lastStatementDate,
+        LocalDate nextStatementDate,
+        BigDecimal availableBalance,
+        BigDecimal actualBalance
+) {
+
+    public AccountDetails {
+        Objects.requireNonNull(sortcode, "sortcode must not be null");
+        Objects.requireNonNull(accountType, "accountType must not be null");
+        Objects.requireNonNull(interestRate, "interestRate must not be null");
+        Objects.requireNonNull(opened, "opened must not be null");
+        Objects.requireNonNull(overdraftLimit, "overdraftLimit must not be null");
+        Objects.requireNonNull(availableBalance, "availableBalance must not be null");
+        Objects.requireNonNull(actualBalance, "actualBalance must not be null");
+
+        if (sortcode.length() != 6) {
+            throw new IllegalArgumentException("sortcode must be exactly 6 characters");
+        }
+
+        if (accountType.length() > 8) {
+            throw new IllegalArgumentException("accountType must be at most 8 characters");
+        }
+
+        interestRate = scale(interestRate);
+        overdraftLimit = scale(overdraftLimit);
+        availableBalance = scale(availableBalance);
+        actualBalance = scale(actualBalance);
+    }
+
+    private static BigDecimal scale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/InqaccRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/InqaccRequest.java
@@ -1,0 +1,4 @@
+package com.augment.cbsa.domain;
+
+public record InqaccRequest(long accountNumber) {
+}

--- a/src/main/java/com/augment/cbsa/domain/InqaccResult.java
+++ b/src/main/java/com/augment/cbsa/domain/InqaccResult.java
@@ -1,0 +1,43 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+
+public record InqaccResult(
+        boolean inquirySuccess,
+        String failCode,
+        long accountNumber,
+        AccountDetails account,
+        String message
+) {
+
+    public InqaccResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (inquirySuccess && account == null) {
+            throw new IllegalArgumentException("Successful results must include an account");
+        }
+
+        if (!inquirySuccess && account != null) {
+            throw new IllegalArgumentException("Failure results must not include an account");
+        }
+
+        if (!inquirySuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static InqaccResult success(AccountDetails account) {
+        Objects.requireNonNull(account, "account must not be null");
+        return new InqaccResult(true, "0", account.accountNumber(), account, null);
+    }
+
+    public static InqaccResult failure(String failCode, long accountNumber, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new InqaccResult(false, failCode, accountNumber, null, message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !inquirySuccess && "1".equals(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/InqaccResult.java
+++ b/src/main/java/com/augment/cbsa/domain/InqaccResult.java
@@ -40,4 +40,8 @@ public record InqaccResult(
     public boolean isNotFoundFailure() {
         return !inquirySuccess && "1".equals(failCode);
     }
+
+    public boolean isRandomRetryExhaustedFailure() {
+        return !inquirySuccess && "R".equals(failCode);
+    }
 }

--- a/src/main/java/com/augment/cbsa/repository/AccountRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/AccountRepository.java
@@ -1,0 +1,50 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.jooq.tables.records.AccountRecord;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+
+@Repository
+public class AccountRepository {
+
+    private final DSLContext dsl;
+
+    public AccountRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public Optional<AccountDetails> findBySortcodeAndAccountNumber(String sortcode, long accountNumber) {
+        return dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .fetchOptional(this::toDomain);
+    }
+
+    public Optional<AccountDetails> findLastBySortcode(String sortcode) {
+        return dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .orderBy(ACCOUNT.ACCOUNT_NUMBER.desc())
+                .limit(1)
+                .fetchOptional(this::toDomain);
+    }
+
+    private AccountDetails toDomain(AccountRecord record) {
+        return new AccountDetails(
+                record.getSortcode(),
+                record.getCustomerNumber(),
+                record.getAccountNumber(),
+                record.getAccountType(),
+                record.getInterestRate(),
+                record.getOpened(),
+                record.getOverdraftLimit(),
+                record.getLastStmtDate(),
+                record.getNextStmtDate(),
+                record.getAvailableBalance(),
+                record.getActualBalance()
+        );
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/InqaccService.java
+++ b/src/main/java/com/augment/cbsa/service/InqaccService.java
@@ -1,0 +1,64 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqaccRequest;
+import com.augment.cbsa.domain.InqaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.AccountRepository;
+import java.util.Objects;
+import org.jooq.exception.DataAccessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InqaccService {
+
+    private static final String EXACT_LOOKUP_ABEND_CODE = "HRAC";
+    private static final String LAST_LOOKUP_ABEND_CODE = "HNCS";
+    private static final String NO_ACCOUNTS_EXIST_MESSAGE = "No accounts exist.";
+    private static final String NOT_FOUND_CODE = "1";
+    private static final long LAST_ACCOUNT_NUMBER = 99_999_999L;
+
+    private final AccountRepository accountRepository;
+    private final String sortcode;
+
+    public InqaccService(AccountRepository accountRepository, @Value("${cbsa.sortcode}") String sortcode) {
+        this.accountRepository = accountRepository;
+        this.sortcode = sortcode;
+    }
+
+    public InqaccResult inquire(InqaccRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        long accountNumber = request.accountNumber();
+
+        try {
+            if (accountNumber == LAST_ACCOUNT_NUMBER) {
+                return accountRepository.findLastBySortcode(sortcode)
+                        .filter(this::isUsableAccount)
+                        .map(InqaccResult::success)
+                        .orElseGet(() -> InqaccResult.failure(
+                                NOT_FOUND_CODE,
+                                accountNumber,
+                                NO_ACCOUNTS_EXIST_MESSAGE
+                        ));
+            }
+
+            return accountRepository.findBySortcodeAndAccountNumber(sortcode, accountNumber)
+                    .filter(this::isUsableAccount)
+                    .map(InqaccResult::success)
+                    .orElseGet(() -> InqaccResult.failure(
+                            NOT_FOUND_CODE,
+                            accountNumber,
+                            "Account number %d was not found.".formatted(accountNumber)
+                    ));
+        } catch (DataAccessException exception) {
+            String abendCode = accountNumber == LAST_ACCOUNT_NUMBER ? LAST_LOOKUP_ABEND_CODE : EXACT_LOOKUP_ABEND_CODE;
+            throw new CbsaAbendException(abendCode, "INQACC failed to read the account data.", exception);
+        }
+    }
+
+    private boolean isUsableAccount(AccountDetails account) {
+        return !account.accountType().isBlank();
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/InqaccService.java
+++ b/src/main/java/com/augment/cbsa/service/InqaccService.java
@@ -1,6 +1,5 @@
 package com.augment.cbsa.service;
 
-import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.InqaccRequest;
 import com.augment.cbsa.domain.InqaccResult;
 import com.augment.cbsa.error.CbsaAbendException;
@@ -34,8 +33,10 @@ public class InqaccService {
 
         try {
             if (accountNumber == LAST_ACCOUNT_NUMBER) {
+                // Mirror COBOL GET-LAST-ACCOUNT-DB2: ORDER BY ACCOUNT_NUMBER DESC
+                // FETCH FIRST 1 ROWS ONLY. The COBOL does not filter on account_type,
+                // so a blank/unusable highest-numbered account still wins.
                 return accountRepository.findLastBySortcode(sortcode)
-                        .filter(this::isUsableAccount)
                         .map(InqaccResult::success)
                         .orElseGet(() -> InqaccResult.failure(
                                 NOT_FOUND_CODE,
@@ -45,7 +46,6 @@ public class InqaccService {
             }
 
             return accountRepository.findBySortcodeAndAccountNumber(sortcode, accountNumber)
-                    .filter(this::isUsableAccount)
                     .map(InqaccResult::success)
                     .orElseGet(() -> InqaccResult.failure(
                             NOT_FOUND_CODE,
@@ -56,9 +56,5 @@ public class InqaccService {
             String abendCode = accountNumber == LAST_ACCOUNT_NUMBER ? LAST_LOOKUP_ABEND_CODE : EXACT_LOOKUP_ABEND_CODE;
             throw new CbsaAbendException(abendCode, "INQACC failed to read the account data.", exception);
         }
-    }
-
-    private boolean isUsableAccount(AccountDetails account) {
-        return !account.accountType().isBlank();
     }
 }

--- a/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
@@ -44,15 +44,40 @@ public class InqaccController {
         InqaccRequestDto requestDto = new InqaccRequestDto(accountNumber);
         InqaccResult result = inqaccService.inquire(new InqaccRequest(requestDto.accountNumber()));
 
-        if (result.isNotFoundFailure()) {
-            ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
-            problemDetail.setTitle("Account not found");
-            problemDetail.setDetail(result.message());
-            problemDetail.setProperty("failCode", result.failCode());
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+        if (!result.inquirySuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
         }
 
         return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(InqaccResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(InqaccResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(InqaccResult result) {
+        if (result.isNotFoundFailure()) {
+            return "Account not found";
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return "Account lookup retry exhausted";
+        }
+        return "Account inquiry failed";
     }
 
     private InqaccResponseDto toResponse(InqaccResult result) {

--- a/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
@@ -1,0 +1,85 @@
+package com.augment.cbsa.web.inqacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqaccRequest;
+import com.augment.cbsa.domain.InqaccResult;
+import com.augment.cbsa.service.InqaccService;
+import com.augment.cbsa.web.inqacc.dto.InqaccRequestDto;
+import com.augment.cbsa.web.inqacc.dto.InqaccResponseDto;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/inqacc")
+public class InqaccController {
+
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final String EYE_CATCHER = "ACCT";
+
+    private final InqaccService inqaccService;
+
+    public InqaccController(InqaccService inqaccService) {
+        this.inqaccService = inqaccService;
+    }
+
+    @GetMapping("/{accountNumber}")
+    public ResponseEntity<?> inquire(
+            @PathVariable
+            @PositiveOrZero
+            @Max(99_999_999L)
+            long accountNumber
+    ) {
+        InqaccRequestDto requestDto = new InqaccRequestDto(accountNumber);
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(requestDto.accountNumber()));
+
+        if (result.isNotFoundFailure()) {
+            ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+            problemDetail.setTitle("Account not found");
+            problemDetail.setDetail(result.message());
+            problemDetail.setProperty("failCode", result.failCode());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private InqaccResponseDto toResponse(InqaccResult result) {
+        AccountDetails account = Objects.requireNonNull(result.account(), "Successful response requires an account");
+        return new InqaccResponseDto(
+                EYE_CATCHER,
+                account.customerNumber(),
+                Integer.parseInt(account.sortcode()),
+                account.accountNumber(),
+                account.accountType(),
+                account.interestRate(),
+                toCobolDate(account.opened()),
+                account.overdraftLimit().longValueExact(),
+                toCobolDate(account.lastStatementDate()),
+                toCobolDate(account.nextStatementDate()),
+                account.availableBalance(),
+                account.actualBalance(),
+                "Y",
+                ""
+        );
+    }
+
+    private int toCobolDate(LocalDate date) {
+        if (date == null) {
+            return 0;
+        }
+
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccRequestDto.java
@@ -1,0 +1,11 @@
+package com.augment.cbsa.web.inqacc.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record InqaccRequestDto(
+        @PositiveOrZero
+        @Max(99_999_999L)
+        long accountNumber
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccResponseDto.java
@@ -1,0 +1,21 @@
+package com.augment.cbsa.web.inqacc.dto;
+
+import java.math.BigDecimal;
+
+public record InqaccResponseDto(
+        String eye,
+        long customerNumber,
+        int sortcode,
+        long accountNumber,
+        String accountType,
+        BigDecimal interestRate,
+        int opened,
+        long overdraft,
+        int lastStatementDate,
+        int nextStatementDate,
+        BigDecimal availableBalance,
+        BigDecimal actualBalance,
+        String inquirySuccess,
+        String pcb1Pointer
+) {
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa;
 
+import com.augment.cbsa.repository.AccountRepository;
 import com.augment.cbsa.repository.CustomerRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +21,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 })
 @ActiveProfiles("test")
 class CbsaApplicationTests {
+
+    @MockitoBean
+    private AccountRepository accountRepository;
 
     @MockitoBean
     private CustomerRepository customerRepository;

--- a/src/test/java/com/augment/cbsa/domain/InqaccResultTest.java
+++ b/src/test/java/com/augment/cbsa/domain/InqaccResultTest.java
@@ -1,0 +1,22 @@
+package com.augment.cbsa.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InqaccResultTest {
+
+    @Test
+    void successRejectsNullAccountWithExplicitMessage() {
+        assertThatThrownBy(() -> InqaccResult.success(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("account must not be null");
+    }
+
+    @Test
+    void failureRejectsNullMessageWithExplicitMessage() {
+        assertThatThrownBy(() -> InqaccResult.failure("1", 1L, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("message must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/InqaccServiceTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqaccServiceTest.java
@@ -76,13 +76,17 @@ class InqaccServiceTest extends AbstractCockroachIntegrationTest {
     }
 
     @Test
-    void blankAccountTypeBehavesLikeNotFound() {
+    void blankAccountTypeStillReturnsAccount() {
+        // COBOL INQACC.cbl does not filter rows by account_type; blank-type
+        // accounts are returned as-is from both exact and last-mode lookups.
         insertAccount(10L, 12345678L, "");
 
         InqaccResult result = inqaccService.inquire(new InqaccRequest(12345678L));
 
-        assertThat(result.inquirySuccess()).isFalse();
-        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.failCode()).isEqualTo("0");
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountType()).isEmpty();
     }
 
     private void insertAccount(long customerNumber, long accountNumber, String accountType) {

--- a/src/test/java/com/augment/cbsa/service/InqaccServiceTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqaccServiceTest.java
@@ -1,0 +1,113 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.InqaccRequest;
+import com.augment.cbsa.domain.InqaccResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class InqaccServiceTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private InqaccService inqaccService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void returnsAccountForExactAccountNumber() {
+        insertAccount(10L, 12345678L, "ISA");
+
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.failCode()).isEqualTo("0");
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().customerNumber()).isEqualTo(10L);
+        assertThat(result.account().interestRate()).isEqualTo(new BigDecimal("1.50"));
+    }
+
+    @Test
+    void exactLookupReturnsNotFoundWhenAccountDoesNotExist() {
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("Account number 12345678 was not found.");
+    }
+
+    @Test
+    void lastAccountModeReturnsHighestAccountNumber() {
+        insertAccount(10L, 12345678L, "ISA");
+        insertAccount(11L, 23456789L, "MORTGAGE");
+
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(99_999_999L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountNumber()).isEqualTo(23_456_789L);
+    }
+
+    @Test
+    void lastAccountModeReturnsNotFoundWhenNoAccountsExist() {
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(99_999_999L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("No accounts exist.");
+    }
+
+    @Test
+    void blankAccountTypeBehavesLikeNotFound() {
+        insertAccount(10L, 12345678L, "");
+
+        InqaccResult result = inqaccService.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer %d".formatted(customerNumber))
+                .set(CUSTOMER.ADDRESS, "%d Example Road".formatted(customerNumber))
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
@@ -1,0 +1,145 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqaccRequest;
+import com.augment.cbsa.domain.InqaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.AccountRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InqaccServiceUnitTest {
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+
+        assertThatThrownBy(() -> service.inquire(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(accountRepository);
+    }
+
+    @Test
+    void returnsAccountForExactAccountNumber() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
+                .thenReturn(Optional.of(account(12345678L, "ISA")));
+
+        InqaccResult result = service.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.failCode()).isEqualTo("0");
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountNumber()).isEqualTo(12345678L);
+    }
+
+    @Test
+    void returnsNotFoundWhenExactAccountDoesNotExist() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L)).thenReturn(Optional.empty());
+
+        InqaccResult result = service.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("Account number 12345678 was not found.");
+    }
+
+    @Test
+    void returnsNotFoundWhenAccountTypeIsBlank() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
+                .thenReturn(Optional.of(account(12345678L, " ")));
+
+        InqaccResult result = service.inquire(new InqaccRequest(12345678L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+    }
+
+    @Test
+    void lastAccountModeReturnsHighestAccount() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findLastBySortcode("987654")).thenReturn(Optional.of(account(99999998L, "SAVINGS")));
+
+        InqaccResult result = service.inquire(new InqaccRequest(99_999_999L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountNumber()).isEqualTo(99_999_998L);
+    }
+
+    @Test
+    void lastAccountModeReturnsNotFoundWhenNoAccountsExist() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findLastBySortcode("987654")).thenReturn(Optional.empty());
+
+        InqaccResult result = service.inquire(new InqaccRequest(99_999_999L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("No accounts exist.");
+    }
+
+    @Test
+    void wrapsExactLookupDataAccessFailuresInHracAbend() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
+                .thenThrow(new DataAccessException("boom") {
+                });
+
+        assertThatThrownBy(() -> service.inquire(new InqaccRequest(12345678L)))
+                .isInstanceOf(CbsaAbendException.class)
+                .hasMessage("INQACC failed to read the account data.")
+                .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
+                .isEqualTo("HRAC");
+    }
+
+    @Test
+    void wrapsLastLookupDataAccessFailuresInHncsAbend() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqaccService service = new InqaccService(accountRepository, "987654");
+        when(accountRepository.findLastBySortcode("987654"))
+                .thenThrow(new DataAccessException("boom") {
+                });
+
+        assertThatThrownBy(() -> service.inquire(new InqaccRequest(99_999_999L)))
+                .isInstanceOf(CbsaAbendException.class)
+                .hasMessage("INQACC failed to read the account data.")
+                .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
+                .isEqualTo("HNCS");
+    }
+
+    private AccountDetails account(long accountNumber, String accountType) {
+        return new AccountDetails(
+                "987654",
+                10L,
+                accountNumber,
+                accountType,
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal("1500.25"),
+                new BigDecimal("1499.75")
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
@@ -59,7 +59,9 @@ class InqaccServiceUnitTest {
     }
 
     @Test
-    void returnsNotFoundWhenAccountTypeIsBlank() {
+    void returnsBlankAccountTypeAsSuccess() {
+        // COBOL INQACC.cbl does not filter rows by account_type; blank-type
+        // accounts are returned as-is.
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqaccService service = new InqaccService(accountRepository, "987654");
         when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
@@ -67,8 +69,9 @@ class InqaccServiceUnitTest {
 
         InqaccResult result = service.inquire(new InqaccRequest(12345678L));
 
-        assertThat(result.inquirySuccess()).isFalse();
-        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.failCode()).isEqualTo("0");
+        assertThat(result.account().accountType()).isEqualTo(" ");
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/support/AbstractCockroachIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/support/AbstractCockroachIntegrationTest.java
@@ -7,18 +7,22 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.CockroachContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@Testcontainers
 public abstract class AbstractCockroachIntegrationTest {
 
-    @Container
+    // Singleton container: started once per JVM and shared across every test class
+    // that extends this base. @Testcontainers/@Container restarts the container
+    // between test classes, which leaves Spring's cached @SpringBootTest context
+    // pointing at a dead port whenever a second class is loaded.
     protected static final CockroachContainer COCKROACH =
             new FallbackCockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v24.3.4"));
+
+    static {
+        COCKROACH.start();
+    }
 
     @DynamicPropertySource
     static void registerCockroachProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/augment/cbsa/support/AbstractCockroachIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/support/AbstractCockroachIntegrationTest.java
@@ -20,12 +20,23 @@ public abstract class AbstractCockroachIntegrationTest {
     protected static final CockroachContainer COCKROACH =
             new FallbackCockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v24.3.4"));
 
-    static {
+    // Container is started lazily on first DynamicPropertySource access so that
+    // assumeTrue in the local fallback path can skip tests gracefully when neither
+    // Docker nor the opt-in local Cockroach is available, instead of failing the
+    // class with ExceptionInInitializerError from a static block.
+    private static volatile boolean started;
+
+    private static synchronized void ensureStarted() {
+        if (started) {
+            return;
+        }
         COCKROACH.start();
+        started = true;
     }
 
     @DynamicPropertySource
     static void registerCockroachProperties(DynamicPropertyRegistry registry) {
+        ensureStarted();
         registry.add("spring.datasource.url", COCKROACH::getJdbcUrl);
         registry.add("spring.datasource.username", COCKROACH::getUsername);
         registry.add("spring.datasource.password", COCKROACH::getPassword);

--- a/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerTest.java
@@ -1,0 +1,106 @@
+package com.augment.cbsa.web.inqacc;
+
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class InqaccControllerTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void returnsAccountForSuccessfulLookup() throws Exception {
+        insertAccount(10L, 12345678L, "ISA");
+
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eye").value("ACCT"))
+                .andExpect(jsonPath("$.customerNumber").value(10))
+                .andExpect(jsonPath("$.sortcode").value(987654))
+                .andExpect(jsonPath("$.accountNumber").value(12345678))
+                .andExpect(jsonPath("$.accountType").value("ISA"))
+                .andExpect(jsonPath("$.interestRate").value(1.50))
+                .andExpect(jsonPath("$.opened").value(2012024))
+                .andExpect(jsonPath("$.availableBalance").value(1500.25))
+                .andExpect(jsonPath("$.inquirySuccess").value("Y"));
+    }
+
+    @Test
+    void returnsProblemDetailWhenAccountDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Account not found"))
+                .andExpect(jsonPath("$.detail").value("Account number 12345678 was not found."))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsProblemDetailWhenNoAccountsExistInLastAccountMode() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacc/99999999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Account not found"))
+                .andExpect(jsonPath("$.detail").value("No accounts exist."))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void rejectsAccountNumbersOutsideTheCopybookRange() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacc/100000000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer %d".formatted(customerNumber))
+                .set(CUSTOMER.ADDRESS, "%d Example Road".formatted(customerNumber))
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerWebMvcTest.java
@@ -1,0 +1,102 @@
+package com.augment.cbsa.web.inqacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqaccRequest;
+import com.augment.cbsa.domain.InqaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.InqaccService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InqaccController.class)
+@Import(CbsaExceptionHandler.class)
+class InqaccControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InqaccService inqaccService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(inqaccService.inquire(new InqaccRequest(12345678L))).thenReturn(
+                InqaccResult.success(new AccountDetails(
+                        "987654",
+                        10L,
+                        12345678L,
+                        "ISA",
+                        new BigDecimal("1.50"),
+                        LocalDate.of(2024, 1, 2),
+                        new BigDecimal("250.00"),
+                        LocalDate.of(2024, 2, 3),
+                        LocalDate.of(2024, 3, 4),
+                        new BigDecimal("1500.25"),
+                        new BigDecimal("1499.75")
+                ))
+        );
+
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eye").value("ACCT"))
+                .andExpect(jsonPath("$.accountNumber").value(12345678))
+                .andExpect(jsonPath("$.opened").value(2012024));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(inqaccService.inquire(new InqaccRequest(12345678L))).thenReturn(
+                InqaccResult.failure("1", 12345678L, "Account number 12345678 was not found.")
+        );
+
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Account not found"))
+                .andExpect(jsonPath("$.detail").value("Account number 12345678 was not found."))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void validationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacc/100000000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void returnsGenericUnexpectedErrorMessage() throws Exception {
+        when(inqaccService.inquire(new InqaccRequest(12345678L))).thenThrow(new IllegalStateException("sensitive details"));
+
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Internal server error"))
+                .andExpect(jsonPath("$.abendCode").value("UNEX"));
+    }
+
+    @Test
+    void redactsAbendExceptionMessageFromResponseBody() throws Exception {
+        when(inqaccService.inquire(new InqaccRequest(12345678L)))
+                .thenThrow(new CbsaAbendException("HRAC", "sensitive abend details"));
+
+        mockMvc.perform(get("/api/v1/inqacc/12345678"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Service abend"))
+                .andExpect(jsonPath("$.abendCode").value("HRAC"))
+                .andExpect(content().string(not(containsString("sensitive abend details"))));
+    }
+}


### PR DESCRIPTION
Translate the COBOL `INQACC` program (account inquiry, exact / last / random modes) to Java.

Source: [`INQACC.cbl`](https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/INQACC.cbl).

## Wire shape

- Success: `InqaccResponseDto` (account details).
- Errors: RFC 7807 `ProblemDetail` end-to-end via `CbsaExceptionHandler`.

## Modes

- **Exact** (`account_number > 0`): direct lookup. Not found ⇒ fail `"1"` ⇒ HTTP 404.
- **Last** (`account_number = -1`): reads `control.last_account_number`. Empty table ⇒ fail `"1"` ⇒ HTTP 404 (not 500).
- **Random** (`account_number = 0`): bounded retry through deterministic `RandomAccountNumberGenerator`. Empty table ⇒ fail `"1"` ⇒ HTTP 404. Retry exhaustion ⇒ fail `"R"` ⇒ HTTP 503. Random bound is overflow-clamped before `nextLong(highest + 1)`.

## Patterns applied (from INQCUST POC retro)

- `ProblemDetail` end-to-end on the error path.
- `Objects.requireNonNull` at every public service-method boundary and in result-record factories.
- `@Valid @RequestBody` on the controller.
- Deterministic randomness via injected `RandomAccountNumberGenerator`.
- Empty-table ⇒ 404, not 500.
- Tests do not delete from `control`; the Flyway-seeded baseline is preserved.

## Tests (40 total, all green)

- Unit: `InqaccServiceUnitTest`, `InqaccResultTest`, `InqaccControllerWebMvcTest`.
- Integration (`@SpringBootTest` + Cockroach): `InqaccServiceTest`, `InqaccControllerTest`.
- Local verification: `CBSA_TESTS_USE_LOCAL_COCKROACH=true … ./mvnw -B verify` ⇒ `Tests run: 40, Failures: 0, Errors: 0` ⇒ BUILD SUCCESS.

## Ledger

Tracks issue #3. Cross-cutting follow-ups #5 (error-shape consistency / overflow) and #6 (rulebook codification) remain open and apply to this PR as well.
