### PR TITLE
feat(inqaccu): translate INQACCCU to Java

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/InqacccuRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/InqacccuRequest.java
@@ -1,0 +1,4 @@
+package com.augment.cbsa.domain;
+
+public record InqacccuRequest(long customerNumber) {
+}

--- a/src/main/java/com/augment/cbsa/domain/InqacccuResult.java
+++ b/src/main/java/com/augment/cbsa/domain/InqacccuResult.java
@@ -1,0 +1,48 @@
+package com.augment.cbsa.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+public record InqacccuResult(
+        boolean inquirySuccess,
+        String failCode,
+        long customerNumber,
+        boolean customerFound,
+        List<AccountDetails> accounts,
+        String message
+) {
+
+    public InqacccuResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(accounts, "accounts must not be null");
+        accounts = List.copyOf(accounts);
+
+        if (inquirySuccess && !customerFound) {
+            throw new IllegalArgumentException("Successful results must mark the customer as found");
+        }
+
+        if (!inquirySuccess && !accounts.isEmpty()) {
+            throw new IllegalArgumentException("Failure results must not include account data");
+        }
+
+        if (!inquirySuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static InqacccuResult success(long customerNumber, List<AccountDetails> accounts) {
+        return new InqacccuResult(true, "0", customerNumber, true, accounts, null);
+    }
+
+    public static InqacccuResult failure(String failCode, long customerNumber, boolean customerFound, String message) {
+        return new InqacccuResult(false, failCode, customerNumber, customerFound, List.of(), message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !inquirySuccess && "1".equals(failCode);
+    }
+
+    public boolean isRandomRetryExhaustedFailure() {
+        return !inquirySuccess && "R".equals(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/AccountRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/AccountRepository.java
@@ -78,7 +78,7 @@ public class AccountRepository {
         private final Cursor<AccountRecord> cursor;
 
         public CustomerAccountsCursor(Cursor<AccountRecord> cursor) {
-            this.cursor = cursor;
+            this.cursor = java.util.Objects.requireNonNull(cursor, "cursor must not be null");
         }
 
         private Cursor<AccountRecord> cursor() {

--- a/src/main/java/com/augment/cbsa/repository/AccountRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/AccountRepository.java
@@ -3,6 +3,7 @@ package com.augment.cbsa.repository;
 import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.jooq.tables.records.AccountRecord;
 import java.util.Optional;
+import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Repository;
 
@@ -32,6 +33,30 @@ public class AccountRepository {
                 .fetchOptional(this::toDomain);
     }
 
+    public CustomerAccountsCursor openCustomerAccountsCursor(String sortcode, long customerNumber) {
+        return new CustomerAccountsCursor(
+                dsl.selectFrom(ACCOUNT)
+                        .where(ACCOUNT.SORTCODE.eq(sortcode))
+                        .and(ACCOUNT.CUSTOMER_NUMBER.eq(customerNumber))
+                        .orderBy(ACCOUNT.ACCOUNT_NUMBER.asc())
+                        .limit(20)
+                        .fetchLazy()
+        );
+    }
+
+    public Optional<AccountDetails> fetchNext(CustomerAccountsCursor cursor) {
+        AccountRecord record = cursor.cursor().fetchNext();
+        if (record == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(toDomain(record));
+    }
+
+    public void close(CustomerAccountsCursor cursor) {
+        cursor.cursor().close();
+    }
+
     private AccountDetails toDomain(AccountRecord record) {
         return new AccountDetails(
                 record.getSortcode(),
@@ -46,5 +71,18 @@ public class AccountRepository {
                 record.getAvailableBalance(),
                 record.getActualBalance()
         );
+    }
+
+    public static class CustomerAccountsCursor {
+
+        private final Cursor<AccountRecord> cursor;
+
+        public CustomerAccountsCursor(Cursor<AccountRecord> cursor) {
+            this.cursor = cursor;
+        }
+
+        private Cursor<AccountRecord> cursor() {
+            return cursor;
+        }
     }
 }

--- a/src/main/java/com/augment/cbsa/service/InqacccuService.java
+++ b/src/main/java/com/augment/cbsa/service/InqacccuService.java
@@ -1,0 +1,113 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.repository.AccountRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jooq.exception.DataAccessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class InqacccuService {
+
+    private static final String NOT_FOUND_CODE = "1";
+    private static final String OPEN_FAILURE_CODE = "2";
+    private static final String FETCH_FAILURE_CODE = "3";
+    private static final String CLOSE_FAILURE_CODE = "4";
+    private static final long ZERO_CUSTOMER_NUMBER = 0L;
+    private static final long LAST_CUSTOMER_NUMBER = 9_999_999_999L;
+
+    private final AccountRepository accountRepository;
+    private final InqcustService inqcustService;
+    private final String sortcode;
+
+    public InqacccuService(
+            AccountRepository accountRepository,
+            InqcustService inqcustService,
+            @Value("${cbsa.sortcode}") String sortcode
+    ) {
+        this.accountRepository = accountRepository;
+        this.inqcustService = inqcustService;
+        this.sortcode = sortcode;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+    public InqacccuResult inquire(InqacccuRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        long customerNumber = request.customerNumber();
+        if (customerNumber == ZERO_CUSTOMER_NUMBER || customerNumber == LAST_CUSTOMER_NUMBER) {
+            return customerNotFound(customerNumber);
+        }
+
+        InqcustResult customerResult = inqcustService.inquire(new InqcustRequest(customerNumber));
+        if (!customerResult.inquirySuccess()) {
+            return customerNotFound(customerNumber);
+        }
+
+        AccountRepository.CustomerAccountsCursor cursor;
+        try {
+            cursor = accountRepository.openCustomerAccountsCursor(sortcode, customerNumber);
+        } catch (DataAccessException exception) {
+            return InqacccuResult.failure(
+                    OPEN_FAILURE_CODE,
+                    customerNumber,
+                    false,
+                    "INQACCCU failed to open the account cursor."
+            );
+        }
+
+        List<AccountDetails> accounts = new ArrayList<>();
+        InqacccuResult pendingFailure = null;
+        try {
+            while (true) {
+                var nextAccount = accountRepository.fetchNext(cursor);
+                if (nextAccount.isEmpty()) {
+                    break;
+                }
+                accounts.add(nextAccount.get());
+            }
+        } catch (DataAccessException exception) {
+            pendingFailure = InqacccuResult.failure(
+                    FETCH_FAILURE_CODE,
+                    customerNumber,
+                    false,
+                    "INQACCCU failed while fetching account data."
+            );
+        }
+
+        try {
+            accountRepository.close(cursor);
+        } catch (DataAccessException exception) {
+            return InqacccuResult.failure(
+                    CLOSE_FAILURE_CODE,
+                    customerNumber,
+                    false,
+                    "INQACCCU failed to close the account cursor."
+            );
+        }
+
+        if (pendingFailure != null) {
+            return pendingFailure;
+        }
+
+        return InqacccuResult.success(customerNumber, accounts);
+    }
+
+    private InqacccuResult customerNotFound(long customerNumber) {
+        return InqacccuResult.failure(
+                NOT_FOUND_CODE,
+                customerNumber,
+                false,
+                "Customer number %d was not found.".formatted(customerNumber)
+        );
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/InqacccuService.java
+++ b/src/main/java/com/augment/cbsa/service/InqacccuService.java
@@ -71,31 +71,33 @@ public class InqacccuService {
         List<AccountDetails> accounts = new ArrayList<>();
         InqacccuResult pendingFailure = null;
         try {
-            while (true) {
-                var nextAccount = accountRepository.fetchNext(cursor);
-                if (nextAccount.isEmpty()) {
-                    break;
+            try {
+                while (true) {
+                    var nextAccount = accountRepository.fetchNext(cursor);
+                    if (nextAccount.isEmpty()) {
+                        break;
+                    }
+                    accounts.add(nextAccount.get());
                 }
-                accounts.add(nextAccount.get());
+            } catch (DataAccessException exception) {
+                pendingFailure = InqacccuResult.failure(
+                        FETCH_FAILURE_CODE,
+                        customerNumber,
+                        true,
+                        "INQACCCU failed while fetching account data."
+                );
             }
-        } catch (DataAccessException exception) {
-            pendingFailure = InqacccuResult.failure(
-                    FETCH_FAILURE_CODE,
-                    customerNumber,
-                    true,
-                    "INQACCCU failed while fetching account data."
-            );
-        }
-
-        try {
-            accountRepository.close(cursor);
-        } catch (DataAccessException exception) {
-            return InqacccuResult.failure(
-                    CLOSE_FAILURE_CODE,
-                    customerNumber,
-                    true,
-                    "INQACCCU failed to close the account cursor."
-            );
+        } finally {
+            try {
+                accountRepository.close(cursor);
+            } catch (DataAccessException exception) {
+                pendingFailure = InqacccuResult.failure(
+                        CLOSE_FAILURE_CODE,
+                        customerNumber,
+                        true,
+                        "INQACCCU failed to close the account cursor."
+                );
+            }
         }
 
         if (pendingFailure != null) {

--- a/src/main/java/com/augment/cbsa/service/InqacccuService.java
+++ b/src/main/java/com/augment/cbsa/service/InqacccuService.java
@@ -53,6 +53,9 @@ public class InqacccuService {
             return customerNotFound(customerNumber);
         }
 
+        // The customer was confirmed to exist via inqcustService above; cursor
+        // open/fetch/close failures are downstream of that confirmation, so the
+        // customerFound flag stays true on those failures.
         AccountRepository.CustomerAccountsCursor cursor;
         try {
             cursor = accountRepository.openCustomerAccountsCursor(sortcode, customerNumber);
@@ -60,7 +63,7 @@ public class InqacccuService {
             return InqacccuResult.failure(
                     OPEN_FAILURE_CODE,
                     customerNumber,
-                    false,
+                    true,
                     "INQACCCU failed to open the account cursor."
             );
         }
@@ -79,7 +82,7 @@ public class InqacccuService {
             pendingFailure = InqacccuResult.failure(
                     FETCH_FAILURE_CODE,
                     customerNumber,
-                    false,
+                    true,
                     "INQACCCU failed while fetching account data."
             );
         }
@@ -90,7 +93,7 @@ public class InqacccuService {
             return InqacccuResult.failure(
                     CLOSE_FAILURE_CODE,
                     customerNumber,
-                    false,
+                    true,
                     "INQACCCU failed to close the account cursor."
             );
         }

--- a/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
@@ -1,0 +1,123 @@
+package com.augment.cbsa.web.inqacccu;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.service.InqacccuService;
+import com.augment.cbsa.web.inqacccu.dto.InqacccuAccountDto;
+import com.augment.cbsa.web.inqacccu.dto.InqacccuRequestDto;
+import com.augment.cbsa.web.inqacccu.dto.InqacccuResponseDto;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/inqacccu")
+public class InqacccuController {
+
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final String EYE_CATCHER = "ACCT";
+
+    private final InqacccuService inqacccuService;
+
+    public InqacccuController(InqacccuService inqacccuService) {
+        this.inqacccuService = inqacccuService;
+    }
+
+    @GetMapping("/{customerNumber}")
+    public ResponseEntity<?> inquire(
+            @PathVariable
+            @PositiveOrZero
+            @Max(9_999_999_999L)
+            long customerNumber
+    ) {
+        InqacccuRequestDto requestDto = new InqacccuRequestDto(customerNumber);
+        InqacccuResult result = inqacccuService.inquire(new InqacccuRequest(requestDto.customerNumber()));
+
+        if (!result.inquirySuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(InqacccuResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(InqacccuResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(InqacccuResult result) {
+        if (result.isNotFoundFailure()) {
+            return "Customer not found";
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return "Customer account inquiry retry exhausted";
+        }
+        return "Customer account inquiry failed";
+    }
+
+    private InqacccuResponseDto toResponse(InqacccuResult result) {
+        List<InqacccuAccountDto> accountDetails = result.accounts().stream()
+                .map(this::toAccountDto)
+                .toList();
+
+        return new InqacccuResponseDto(
+                result.customerNumber(),
+                "Y",
+                result.failCode(),
+                result.customerFound() ? "Y" : "N",
+                "",
+                accountDetails
+        );
+    }
+
+    private InqacccuAccountDto toAccountDto(AccountDetails account) {
+        return new InqacccuAccountDto(
+                EYE_CATCHER,
+                account.customerNumber(),
+                account.sortcode(),
+                account.accountNumber(),
+                account.accountType(),
+                account.interestRate(),
+                toCobolDate(account.opened()),
+                account.overdraftLimit().longValueExact(),
+                toCobolDate(account.lastStatementDate()),
+                toCobolDate(account.nextStatementDate()),
+                account.availableBalance(),
+                account.actualBalance()
+        );
+    }
+
+    private int toCobolDate(LocalDate date) {
+        if (date == null) {
+            return 0;
+        }
+
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
@@ -105,7 +105,7 @@ public class InqacccuController {
                 account.accountType(),
                 account.interestRate(),
                 toCobolDate(account.opened()),
-                account.overdraftLimit().longValueExact(),
+                account.overdraftLimit().toBigInteger().longValueExact(),
                 toCobolDate(account.lastStatementDate()),
                 toCobolDate(account.nextStatementDate()),
                 account.availableBalance(),

--- a/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuAccountDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuAccountDto.java
@@ -1,0 +1,19 @@
+package com.augment.cbsa.web.inqacccu.dto;
+
+import java.math.BigDecimal;
+
+public record InqacccuAccountDto(
+        String eye,
+        long customerNumber,
+        String sortcode,
+        long accountNumber,
+        String accountType,
+        BigDecimal interestRate,
+        int opened,
+        long overdraft,
+        int lastStatementDate,
+        int nextStatementDate,
+        BigDecimal availableBalance,
+        BigDecimal actualBalance
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuRequestDto.java
@@ -1,0 +1,11 @@
+package com.augment.cbsa.web.inqacccu.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record InqacccuRequestDto(
+        @PositiveOrZero
+        @Max(9_999_999_999L)
+        long customerNumber
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/dto/InqacccuResponseDto.java
@@ -1,0 +1,13 @@
+package com.augment.cbsa.web.inqacccu.dto;
+
+import java.util.List;
+
+public record InqacccuResponseDto(
+        long customerNumber,
+        String inquirySuccess,
+        String failCode,
+        String customerFound,
+        String pcbPointer,
+        List<InqacccuAccountDto> accountDetails
+) {
+}

--- a/src/test/java/com/augment/cbsa/domain/InqacccuResultTest.java
+++ b/src/test/java/com/augment/cbsa/domain/InqacccuResultTest.java
@@ -1,0 +1,46 @@
+package com.augment.cbsa.domain;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InqacccuResultTest {
+
+    @Test
+    void successRejectsNullAccountsWithExplicitMessage() {
+        assertThatThrownBy(() -> InqacccuResult.success(1L, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("accounts must not be null");
+    }
+
+    @Test
+    void failureRejectsNullMessageWithExplicitMessage() {
+        assertThatThrownBy(() -> InqacccuResult.failure("1", 1L, false, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Failure results must include a non-blank message");
+    }
+
+    @Test
+    void failureRejectsEmbeddedAccounts() {
+        assertThatThrownBy(() -> new InqacccuResult(false, "3", 1L, false, List.of(account()), "boom"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Failure results must not include account data");
+    }
+
+    private AccountDetails account() {
+        return new AccountDetails(
+                "987654",
+                1L,
+                2L,
+                "ISA",
+                new java.math.BigDecimal("1.50"),
+                java.time.LocalDate.of(2024, 1, 2),
+                new java.math.BigDecimal("250.00"),
+                java.time.LocalDate.of(2024, 2, 3),
+                java.time.LocalDate.of(2024, 3, 4),
+                new java.math.BigDecimal("1500.25"),
+                new java.math.BigDecimal("1499.75")
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/InqacccuServiceTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqacccuServiceTest.java
@@ -1,0 +1,96 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class InqacccuServiceTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private InqacccuService inqacccuService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void returnsAllAccountsForExistingCustomerWithoutFilteringBlankTypes() {
+        insertCustomer(10L);
+        insertAccount(10L, 200L, "");
+        insertAccount(10L, 100L, "ISA");
+
+        InqacccuResult result = inqacccuService.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.customerFound()).isTrue();
+        assertThat(result.accounts()).extracting(account -> account.accountNumber()).containsExactly(100L, 200L);
+        assertThat(result.accounts()).extracting(account -> account.accountType()).containsExactly("ISA", "");
+    }
+
+    @Test
+    void returnsSuccessfulEmptyResultWhenCustomerHasNoAccounts() {
+        insertCustomer(10L);
+
+        InqacccuResult result = inqacccuService.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.customerFound()).isTrue();
+        assertThat(result.accounts()).isEmpty();
+    }
+
+    @Test
+    void returnsNotFoundWhenCustomerDoesNotExist() {
+        InqacccuResult result = inqacccuService.inquire(new InqacccuRequest(1234567890L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("Customer number 1234567890 was not found.");
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer %d".formatted(customerNumber))
+                .set(CUSTOMER.ADDRESS, "%d Example Road".formatted(customerNumber))
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
@@ -6,10 +6,12 @@ import com.augment.cbsa.domain.InqacccuRequest;
 import com.augment.cbsa.domain.InqacccuResult;
 import com.augment.cbsa.domain.InqcustRequest;
 import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.jooq.tables.records.AccountRecord;
 import com.augment.cbsa.repository.AccountRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
+import org.jooq.Cursor;
 import org.jooq.exception.DataAccessException;
 import org.junit.jupiter.api.Test;
 
@@ -70,7 +72,7 @@ class InqacccuServiceUnitTest {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
         InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
-        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
         when(accountRepository.fetchNext(cursor))
@@ -107,7 +109,7 @@ class InqacccuServiceUnitTest {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
         InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
-        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
         when(accountRepository.fetchNext(cursor)).thenThrow(new DataAccessException("boom") {
@@ -126,7 +128,7 @@ class InqacccuServiceUnitTest {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
         InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
-        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
         when(accountRepository.fetchNext(cursor)).thenThrow(new DataAccessException("boom") {
@@ -139,6 +141,11 @@ class InqacccuServiceUnitTest {
         assertThat(result.inquirySuccess()).isFalse();
         assertThat(result.failCode()).isEqualTo("4");
         assertThat(result.message()).isEqualTo("INQACCCU failed to close the account cursor.");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Cursor<AccountRecord> mockCursor() {
+        return mock(Cursor.class);
     }
 
     private CustomerDetails customer(long customerNumber) {

--- a/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
@@ -1,0 +1,171 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.repository.AccountRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InqacccuServiceUnitTest {
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+
+        assertThatThrownBy(() -> service.inquire(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(accountRepository, inqcustService);
+    }
+
+    @Test
+    void sentinelCustomerNumbersReturnNotFoundWithoutCallingDependencies() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+
+        InqacccuResult zeroResult = service.inquire(new InqacccuRequest(0L));
+        InqacccuResult lastResult = service.inquire(new InqacccuRequest(9_999_999_999L));
+
+        assertThat(zeroResult.isNotFoundFailure()).isTrue();
+        assertThat(zeroResult.message()).isEqualTo("Customer number 0 was not found.");
+        assertThat(lastResult.isNotFoundFailure()).isTrue();
+        assertThat(lastResult.message()).isEqualTo("Customer number 9999999999 was not found.");
+        verifyNoInteractions(accountRepository, inqcustService);
+    }
+
+    @Test
+    void returnsNotFoundWhenLinkedCustomerInquiryFails() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        when(inqcustService.inquire(new InqcustRequest(10L)))
+                .thenReturn(InqcustResult.failure("1", 10L, "Customer number 10 was not found."));
+
+        InqacccuResult result = service.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.isNotFoundFailure()).isTrue();
+        assertThat(result.message()).isEqualTo("Customer number 10 was not found.");
+        verifyNoInteractions(accountRepository);
+    }
+
+    @Test
+    void returnsAccountsForExistingCustomerIncludingBlankAccountTypes() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
+        when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
+        when(accountRepository.fetchNext(cursor))
+                .thenReturn(Optional.of(account(1L, "ISA")), Optional.of(account(2L, "")), Optional.empty());
+
+        InqacccuResult result = service.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isTrue();
+        assertThat(result.customerFound()).isTrue();
+        assertThat(result.accounts()).extracting(AccountDetails::accountNumber).containsExactly(1L, 2L);
+        assertThat(result.accounts()).extracting(AccountDetails::accountType).containsExactly("ISA", "");
+        verify(accountRepository).close(cursor);
+    }
+
+    @Test
+    void returnsOpenFailureWhenCursorCannotBeOpened() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
+        when(accountRepository.openCustomerAccountsCursor("987654", 10L))
+                .thenThrow(new DataAccessException("boom") {
+                });
+
+        InqacccuResult result = service.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(result.message()).isEqualTo("INQACCCU failed to open the account cursor.");
+    }
+
+    @Test
+    void returnsFetchFailureWhenCursorIterationFails() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
+        when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
+        when(accountRepository.fetchNext(cursor)).thenThrow(new DataAccessException("boom") {
+        });
+
+        InqacccuResult result = service.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("3");
+        assertThat(result.message()).isEqualTo("INQACCCU failed while fetching account data.");
+        verify(accountRepository).close(cursor);
+    }
+
+    @Test
+    void closeFailureOverridesEarlierFetchFailure() {
+        AccountRepository accountRepository = mock(AccountRepository.class);
+        InqcustService inqcustService = mock(InqcustService.class);
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(null);
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
+        when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
+        when(accountRepository.fetchNext(cursor)).thenThrow(new DataAccessException("boom") {
+        });
+        org.mockito.Mockito.doThrow(new DataAccessException("close boom") {
+        }).when(accountRepository).close(cursor);
+
+        InqacccuResult result = service.inquire(new InqacccuRequest(10L));
+
+        assertThat(result.inquirySuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("4");
+        assertThat(result.message()).isEqualTo("INQACCCU failed to close the account cursor.");
+    }
+
+    private CustomerDetails customer(long customerNumber) {
+        return new CustomerDetails(
+                "987654",
+                customerNumber,
+                "Example Customer",
+                "1 Example Road",
+                LocalDate.of(1990, 1, 1),
+                500,
+                LocalDate.of(2025, 1, 1)
+        );
+    }
+
+    private AccountDetails account(long accountNumber, String accountType) {
+        return new AccountDetails(
+                "987654",
+                10L,
+                accountNumber,
+                accountType,
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal("1500.25"),
+                new BigDecimal("1499.75")
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/inqacccu/InqacccuControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/inqacccu/InqacccuControllerTest.java
@@ -1,0 +1,109 @@
+package com.augment.cbsa.web.inqacccu;
+
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class InqacccuControllerTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void returnsAccountsForSuccessfulLookup() throws Exception {
+        insertCustomer(10L);
+        insertAccount(10L, 100L, "ISA");
+        insertAccount(10L, 200L, "");
+
+        mockMvc.perform(get("/api/v1/inqacccu/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerNumber").value(10))
+                .andExpect(jsonPath("$.inquirySuccess").value("Y"))
+                .andExpect(jsonPath("$.customerFound").value("Y"))
+                .andExpect(jsonPath("$.accountDetails[0].eye").value("ACCT"))
+                .andExpect(jsonPath("$.accountDetails[0].sortcode").value("987654"))
+                .andExpect(jsonPath("$.accountDetails[0].accountNumber").value(100))
+                .andExpect(jsonPath("$.accountDetails[1].accountType").value(""));
+    }
+
+    @Test
+    void returnsProblemDetailWhenCustomerDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacccu/1234567890"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.detail").value("Customer number 1234567890 was not found."))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsSuccessfulEmptyArrayWhenCustomerHasNoAccounts() throws Exception {
+        insertCustomer(10L);
+
+        mockMvc.perform(get("/api/v1/inqacccu/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerFound").value("Y"))
+                .andExpect(jsonPath("$.accountDetails").isArray());
+    }
+
+    @Test
+    void rejectsCustomerNumbersOutsideTheCopybookRange() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacccu/10000000000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer %d".formatted(customerNumber))
+                .set(CUSTOMER.ADDRESS, "%d Example Road".formatted(customerNumber))
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/inqacccu/InqacccuControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/inqacccu/InqacccuControllerWebMvcTest.java
@@ -1,0 +1,92 @@
+package com.augment.cbsa.web.inqacccu;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.InqacccuService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InqacccuController.class)
+@Import(CbsaExceptionHandler.class)
+class InqacccuControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InqacccuService inqacccuService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(inqacccuService.inquire(new InqacccuRequest(10L))).thenReturn(
+                InqacccuResult.success(10L, java.util.List.of(new AccountDetails(
+                        "987654",
+                        10L,
+                        100L,
+                        "ISA",
+                        new BigDecimal("1.50"),
+                        LocalDate.of(2024, 1, 2),
+                        new BigDecimal("250.00"),
+                        LocalDate.of(2024, 2, 3),
+                        LocalDate.of(2024, 3, 4),
+                        new BigDecimal("1500.25"),
+                        new BigDecimal("1499.75")
+                )))
+        );
+
+        mockMvc.perform(get("/api/v1/inqacccu/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerNumber").value(10))
+                .andExpect(jsonPath("$.accountDetails[0].eye").value("ACCT"))
+                .andExpect(jsonPath("$.accountDetails[0].opened").value(2012024));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(inqacccuService.inquire(new InqacccuRequest(10L))).thenReturn(
+                InqacccuResult.failure("1", 10L, false, "Customer number 10 was not found.")
+        );
+
+        mockMvc.perform(get("/api/v1/inqacccu/10"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.detail").value("Customer number 10 was not found."))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void validationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(get("/api/v1/inqacccu/10000000000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void redactsAbendExceptionMessageFromResponseBody() throws Exception {
+        when(inqacccuService.inquire(new InqacccuRequest(10L)))
+                .thenThrow(new CbsaAbendException("CVR1", "sensitive abend details"));
+
+        mockMvc.perform(get("/api/v1/inqacccu/10"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Service abend"))
+                .andExpect(jsonPath("$.abendCode").value("CVR1"))
+                .andExpect(content().string(not(containsString("sensitive abend details"))));
+    }
+}


### PR DESCRIPTION
## Source program
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/INQACCCU.cbl

## Mapped REST endpoints
- GET /api/v1/inqacccu/{customerNumber}

## Notable decisions
- Preserved the COBOL INQCUST link semantics by validating customer existence first and treating customer lookup failures as fail code 1 rather than querying accounts directly.
- Modeled the account read as a jOOQ cursor so the Java translation can preserve distinct COBOL-style cursor failure codes for open (2), fetch (3), and close (4).
- Kept the maximum of 20 returned accounts and ordered by account_number for deterministic cursor output while still preserving blank account_type rows.
- Returned ProblemDetail on all failure wire paths, mapping fail code 1 to HTTP 404 and all other commarea failure codes to HTTP 500.
- Reused the shared AccountDetails domain model instead of introducing a copybook-shaped duplicate account entity.

## Test coverage
- Unit: InqacccuResultTest, InqacccuServiceUnitTest
- @SpringBootTest: InqacccuServiceTest
- MockMvc: InqacccuControllerTest
- @WebMvcTest: InqacccuControllerWebMvcTest
