### PR TITLE
feat(creacc): translate CREACC to Java

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/CreaccCommand.java
+++ b/src/main/java/com/augment/cbsa/domain/CreaccCommand.java
@@ -1,0 +1,54 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+
+public record CreaccCommand(
+        String sortcode,
+        long customerNumber,
+        String accountType,
+        BigDecimal interestRate,
+        BigDecimal overdraftLimit,
+        BigDecimal availableBalance,
+        BigDecimal actualBalance,
+        LocalDate opened,
+        LocalDate lastStatementDate,
+        LocalDate nextStatementDate,
+        long transactionReference,
+        LocalDate transactionDate,
+        LocalTime transactionTime
+) {
+
+    public CreaccCommand {
+        Objects.requireNonNull(sortcode, "sortcode must not be null");
+        Objects.requireNonNull(accountType, "accountType must not be null");
+        Objects.requireNonNull(interestRate, "interestRate must not be null");
+        Objects.requireNonNull(overdraftLimit, "overdraftLimit must not be null");
+        Objects.requireNonNull(availableBalance, "availableBalance must not be null");
+        Objects.requireNonNull(actualBalance, "actualBalance must not be null");
+        Objects.requireNonNull(opened, "opened must not be null");
+        Objects.requireNonNull(lastStatementDate, "lastStatementDate must not be null");
+        Objects.requireNonNull(nextStatementDate, "nextStatementDate must not be null");
+        Objects.requireNonNull(transactionDate, "transactionDate must not be null");
+        Objects.requireNonNull(transactionTime, "transactionTime must not be null");
+
+        if (sortcode.length() != 6) {
+            throw new IllegalArgumentException("sortcode must be exactly 6 characters");
+        }
+        if (accountType.length() > 8) {
+            throw new IllegalArgumentException("accountType must be at most 8 characters");
+        }
+
+        interestRate = scale(interestRate);
+        overdraftLimit = scale(overdraftLimit);
+        availableBalance = scale(availableBalance);
+        actualBalance = scale(actualBalance);
+    }
+
+    private static BigDecimal scale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/CreaccRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/CreaccRequest.java
@@ -1,0 +1,40 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+public record CreaccRequest(
+        long customerNumber,
+        String accountType,
+        BigDecimal interestRate,
+        long overdraftLimit,
+        BigDecimal availableBalance,
+        BigDecimal actualBalance
+) {
+
+    public CreaccRequest {
+        Objects.requireNonNull(accountType, "accountType must not be null");
+        Objects.requireNonNull(interestRate, "interestRate must not be null");
+        Objects.requireNonNull(availableBalance, "availableBalance must not be null");
+        Objects.requireNonNull(actualBalance, "actualBalance must not be null");
+
+        if (customerNumber < 0 || customerNumber > 9_999_999_999L) {
+            throw new IllegalArgumentException("customerNumber must be between 0 and 9999999999");
+        }
+        if (accountType.length() > 8) {
+            throw new IllegalArgumentException("accountType must be at most 8 characters");
+        }
+        if (overdraftLimit < 0 || overdraftLimit > 99_999_999L) {
+            throw new IllegalArgumentException("overdraftLimit must be between 0 and 99999999");
+        }
+
+        interestRate = scale(interestRate);
+        availableBalance = scale(availableBalance);
+        actualBalance = scale(actualBalance);
+    }
+
+    private static BigDecimal scale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/CreaccResult.java
+++ b/src/main/java/com/augment/cbsa/domain/CreaccResult.java
@@ -1,0 +1,58 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record CreaccResult(
+        boolean creationSuccess,
+        String failCode,
+        AccountDetails account,
+        String message
+) {
+
+    private static final Set<String> VALIDATION_FAIL_CODES = Set.of("A");
+    private static final Set<String> NOT_FOUND_FAIL_CODES = Set.of("1");
+    private static final Set<String> CAPACITY_FAIL_CODES = Set.of("8");
+    private static final Set<String> TRANSIENT_FAIL_CODES = Set.of("3", "5");
+
+    public CreaccResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (creationSuccess && account == null) {
+            throw new IllegalArgumentException("Successful results must include an account");
+        }
+        if (!creationSuccess && account != null) {
+            throw new IllegalArgumentException("Failure results must not include an account");
+        }
+        if (!creationSuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static CreaccResult success(AccountDetails account) {
+        Objects.requireNonNull(account, "account must not be null");
+        return new CreaccResult(true, " ", account, null);
+    }
+
+    public static CreaccResult failure(String failCode, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new CreaccResult(false, failCode, null, message);
+    }
+
+    public boolean isValidationFailure() {
+        return !creationSuccess && VALIDATION_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !creationSuccess && NOT_FOUND_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isCapacityFailure() {
+        return !creationSuccess && CAPACITY_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isTransientFailure() {
+        return !creationSuccess && TRANSIENT_FAIL_CODES.contains(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
@@ -1,0 +1,173 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CreaccCommand;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.jooq.Record2;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CONTROL;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+
+@Repository
+public class CreaccRepository {
+
+    private static final String GLOBAL_CONTROL_ID = "GLOBAL";
+    private static final String COUNTER_ABEND_CODE = "HNCS";
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
+    private static final long MAX_ACCOUNT_NUMBER = 99_999_999L;
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+
+    private final DSLContext dsl;
+
+    public CreaccRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public CreaccResult createAccount(CreaccCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        try {
+            return CrdbRetry.run(dsl, () -> dsl.transactionResult(configuration -> createAccount(DSL.using(configuration), command)));
+        } catch (RollbackFailureException exception) {
+            return exception.result();
+        } catch (CbsaAbendException exception) {
+            throw exception;
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to persist the account data.", exception);
+        }
+    }
+
+    private CreaccResult createAccount(DSLContext txDsl, CreaccCommand command) {
+        Record2<Long, Long> controlState;
+        try {
+            controlState = txDsl.select(CONTROL.ACCOUNT_COUNT, CONTROL.ACCOUNT_LAST)
+                    .from(CONTROL)
+                    .where(CONTROL.ID.eq(GLOBAL_CONTROL_ID))
+                    .forUpdate()
+                    .fetchOne();
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to reserve the next account number.", exception);
+        }
+
+        if (controlState == null) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC account control record is missing.");
+        }
+
+        long nextAccountNumber = safeIncrement(controlState.value2());
+        long nextAccountCount = safeIncrement(controlState.value1());
+        AccountDetails account = new AccountDetails(
+                command.sortcode(),
+                command.customerNumber(),
+                nextAccountNumber,
+                command.accountType(),
+                command.interestRate(),
+                command.opened(),
+                command.overdraftLimit(),
+                command.lastStatementDate(),
+                command.nextStatementDate(),
+                command.availableBalance(),
+                command.actualBalance()
+        );
+
+        try {
+            int updated = txDsl.update(CONTROL)
+                    .set(CONTROL.ACCOUNT_COUNT, nextAccountCount)
+                    .set(CONTROL.ACCOUNT_LAST, nextAccountNumber)
+                    .where(CONTROL.ID.eq(GLOBAL_CONTROL_ID))
+                    .and(CONTROL.ACCOUNT_COUNT.eq(controlState.value1()))
+                    .and(CONTROL.ACCOUNT_LAST.eq(controlState.value2()))
+                    .execute();
+            if (updated != 1) {
+                throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to update the account counter.");
+            }
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to update the account counter.", exception);
+        }
+
+        try {
+            txDsl.insertInto(ACCOUNT)
+                    .set(ACCOUNT.SORTCODE, account.sortcode())
+                    .set(ACCOUNT.ACCOUNT_NUMBER, account.accountNumber())
+                    .set(ACCOUNT.CUSTOMER_NUMBER, account.customerNumber())
+                    .set(ACCOUNT.ACCOUNT_TYPE, account.accountType())
+                    .set(ACCOUNT.INTEREST_RATE, account.interestRate())
+                    .set(ACCOUNT.OPENED, account.opened())
+                    .set(ACCOUNT.OVERDRAFT_LIMIT, account.overdraftLimit())
+                    .set(ACCOUNT.LAST_STMT_DATE, account.lastStatementDate())
+                    .set(ACCOUNT.NEXT_STMT_DATE, account.nextStatementDate())
+                    .set(ACCOUNT.AVAILABLE_BALANCE, account.availableBalance())
+                    .set(ACCOUNT.ACTUAL_BALANCE, account.actualBalance())
+                    .execute();
+        } catch (DataAccessException exception) {
+            throw rollbackFailure("7", "Unable to create the account record.");
+        }
+
+        try {
+            txDsl.insertInto(PROCTRAN)
+                    .set(PROCTRAN.SORTCODE, account.sortcode())
+                    .set(PROCTRAN.LOGICAL_DELETE, false)
+                    .set(PROCTRAN.TRAN_DATE, command.transactionDate())
+                    .set(PROCTRAN.TRAN_TIME, command.transactionTime())
+                    .set(PROCTRAN.TRAN_REF, command.transactionReference())
+                    .set(PROCTRAN.TRAN_TYPE, "OCA")
+                    .set(PROCTRAN.DESCRIPTION, toDescription(account))
+                    .set(PROCTRAN.AMOUNT, new BigDecimal("0.00"))
+                    .execute();
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(PROCTRAN_ABEND_CODE, "CREACC failed to write the audit trail.", exception);
+        }
+
+        return CreaccResult.success(account);
+    }
+
+    private long safeIncrement(long currentValue) {
+        long nextValue;
+        try {
+            nextValue = Math.addExact(currentValue, 1L);
+        } catch (ArithmeticException exception) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC account numbering has reached its maximum value.", exception);
+        }
+        if (nextValue > MAX_ACCOUNT_NUMBER) {
+            throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC account numbering has reached its maximum value.");
+        }
+        return nextValue;
+    }
+
+    private RollbackFailureException rollbackFailure(String failCode, String message) {
+        return new RollbackFailureException(CreaccResult.failure(failCode, message));
+    }
+
+    private String toDescription(AccountDetails account) {
+        return String.format(
+                Locale.ROOT,
+                "%010d%-8.8s%s%s      ",
+                account.customerNumber(),
+                account.accountType(),
+                account.lastStatementDate().format(COBOL_DATE_FORMATTER),
+                account.nextStatementDate().format(COBOL_DATE_FORMATTER)
+        );
+    }
+
+    private static final class RollbackFailureException extends RuntimeException {
+
+        private final CreaccResult result;
+
+        private RollbackFailureException(CreaccResult result) {
+            this.result = Objects.requireNonNull(result, "result must not be null");
+        }
+
+        private CreaccResult result() {
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
@@ -5,6 +5,7 @@ import com.augment.cbsa.domain.CreaccCommand;
 import com.augment.cbsa.domain.CreaccResult;
 import com.augment.cbsa.error.CbsaAbendException;
 import java.math.BigDecimal;
+import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Objects;
@@ -56,6 +57,11 @@ public class CreaccRepository {
                     .forUpdate()
                     .fetchOne();
         } catch (DataAccessException exception) {
+            // Re-throw serialization failures so CrdbRetry can retry the
+            // whole transaction; only abend on non-retryable errors.
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to reserve the next account number.", exception);
         }
 
@@ -91,6 +97,9 @@ public class CreaccRepository {
                 throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to update the account counter.");
             }
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(COUNTER_ABEND_CODE, "CREACC failed to update the account counter.", exception);
         }
 
@@ -109,6 +118,9 @@ public class CreaccRepository {
                     .set(ACCOUNT.ACTUAL_BALANCE, account.actualBalance())
                     .execute();
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw rollbackFailure("7", "Unable to create the account record.");
         }
 
@@ -124,10 +136,25 @@ public class CreaccRepository {
                     .set(PROCTRAN.AMOUNT, new BigDecimal("0.00"))
                     .execute();
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(PROCTRAN_ABEND_CODE, "CREACC failed to write the audit trail.", exception);
         }
 
         return CreaccResult.success(account);
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException
+                    && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private long safeIncrement(long currentValue) {

--- a/src/main/java/com/augment/cbsa/service/CreaccService.java
+++ b/src/main/java/com/augment/cbsa/service/CreaccService.java
@@ -1,0 +1,97 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CreaccCommand;
+import com.augment.cbsa.domain.CreaccRequest;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.repository.CreaccRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreaccService {
+
+    private static final int MAX_ACCOUNTS_PER_CUSTOMER = 9;
+
+    private final CreaccRepository creaccRepository;
+    private final InqcustService inqcustService;
+    private final InqacccuService inqacccuService;
+    private final String sortcode;
+    private final Clock clock;
+
+    public CreaccService(
+            CreaccRepository creaccRepository,
+            InqcustService inqcustService,
+            InqacccuService inqacccuService,
+            @Value("${cbsa.sortcode}") String sortcode,
+            Clock clock
+    ) {
+        this.creaccRepository = Objects.requireNonNull(creaccRepository, "creaccRepository must not be null");
+        this.inqcustService = Objects.requireNonNull(inqcustService, "inqcustService must not be null");
+        this.inqacccuService = Objects.requireNonNull(inqacccuService, "inqacccuService must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    public CreaccResult create(CreaccRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        if (!isSupportedAccountType(request.accountType())) {
+            return CreaccResult.failure("A", "Account type must be ISA, MORTGAGE, SAVING, CURRENT, or LOAN.");
+        }
+
+        InqcustResult customerResult = inqcustService.inquire(new InqcustRequest(request.customerNumber()));
+        if (!customerResult.inquirySuccess()) {
+            return CreaccResult.failure("1", customerResult.message());
+        }
+
+        InqacccuResult accountCountResult = inqacccuService.inquire(new InqacccuRequest(request.customerNumber()));
+        if (!accountCountResult.inquirySuccess()) {
+            return CreaccResult.failure("9", accountCountResult.message());
+        }
+        if (accountCountResult.accounts().size() > MAX_ACCOUNTS_PER_CUSTOMER) {
+            return CreaccResult.failure(
+                    "8",
+                    "Customer number %d already has the maximum number of accounts.".formatted(request.customerNumber())
+            );
+        }
+
+        Instant now = Instant.now(clock);
+        LocalDate today = LocalDate.ofInstant(now, ZoneOffset.UTC);
+        CreaccCommand command = new CreaccCommand(
+                sortcode,
+                request.customerNumber(),
+                request.accountType(),
+                request.interestRate(),
+                BigDecimal.valueOf(request.overdraftLimit()),
+                request.availableBalance(),
+                request.actualBalance(),
+                today,
+                today,
+                today.plusDays(30),
+                Math.max(0L, now.toEpochMilli()),
+                today,
+                LocalTime.ofInstant(now, ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+        );
+        return creaccRepository.createAccount(command);
+    }
+
+    private boolean isSupportedAccountType(String accountType) {
+        return accountType.startsWith("ISA")
+                || accountType.startsWith("MORTGAGE")
+                || accountType.startsWith("SAVING")
+                || accountType.startsWith("CURRENT")
+                || accountType.startsWith("LOAN");
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/CreaccService.java
+++ b/src/main/java/com/augment/cbsa/service/CreaccService.java
@@ -88,10 +88,17 @@ public class CreaccService {
     }
 
     private boolean isSupportedAccountType(String accountType) {
-        return accountType.startsWith("ISA")
-                || accountType.startsWith("MORTGAGE")
-                || accountType.startsWith("SAVING")
-                || accountType.startsWith("CURRENT")
-                || accountType.startsWith("LOAN");
+        if (accountType == null) {
+            return false;
+        }
+        // COBOL ACCOUNT-TYPE-CHECK compared fixed-length prefixes of an 8-byte
+        // field (e.g. (1:3)='ISA'). Translate by trimming and matching the
+        // exact canonical names so values like "ISAFOO" no longer pass.
+        String trimmed = accountType.trim();
+        return "ISA".equals(trimmed)
+                || "MORTGAGE".equals(trimmed)
+                || "SAVING".equals(trimmed)
+                || "CURRENT".equals(trimmed)
+                || "LOAN".equals(trimmed);
     }
 }

--- a/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
@@ -1,0 +1,114 @@
+package com.augment.cbsa.web.creacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CreaccRequest;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.service.CreaccService;
+import com.augment.cbsa.web.creacc.dto.CreaccCommareaResponseDto;
+import com.augment.cbsa.web.creacc.dto.CreaccKeyDto;
+import com.augment.cbsa.web.creacc.dto.CreaccRequestDto;
+import com.augment.cbsa.web.creacc.dto.CreaccResponseDto;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/creacc")
+public class CreaccController {
+
+    private static final String EYE_CATCHER = "ACCT";
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+
+    private final CreaccService creaccService;
+
+    public CreaccController(CreaccService creaccService) {
+        this.creaccService = Objects.requireNonNull(creaccService, "creaccService must not be null");
+    }
+
+    @PostMapping("/insert")
+    public ResponseEntity<?> create(@Valid @RequestBody CreaccRequestDto requestDto) {
+        CreaccRequest request = new CreaccRequest(
+                requestDto.creAcc().commCustno(),
+                requestDto.creAcc().commAccType(),
+                requestDto.creAcc().commIntRt(),
+                requestDto.creAcc().commOverdrLim(),
+                requestDto.creAcc().commAvailBal(),
+                requestDto.creAcc().commActBal()
+        );
+        CreaccResult result = creaccService.create(request);
+
+        if (!result.creationSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(CreaccResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isValidationFailure()) {
+            return HttpStatus.BAD_REQUEST;
+        }
+        if (result.isCapacityFailure()) {
+            return HttpStatus.CONFLICT;
+        }
+        if (result.isTransientFailure()) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(CreaccResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(CreaccResult result) {
+        return switch (result.failCode()) {
+            case "1" -> "Customer not found";
+            case "8" -> "Maximum account count reached";
+            case "9" -> "Customer account count failed";
+            case "A" -> "Invalid account type";
+            default -> "Account creation failed";
+        };
+    }
+
+    private CreaccResponseDto toResponse(CreaccResult result) {
+        AccountDetails account = Objects.requireNonNull(result.account(), "Successful response requires an account");
+        return new CreaccResponseDto(new CreaccCommareaResponseDto(
+                EYE_CATCHER,
+                account.customerNumber(),
+                new CreaccKeyDto(Integer.parseInt(account.sortcode()), account.accountNumber()),
+                account.accountType(),
+                account.interestRate(),
+                toCobolDate(account.opened()),
+                account.overdraftLimit().longValueExact(),
+                toCobolDate(account.lastStatementDate()),
+                toCobolDate(account.nextStatementDate()),
+                account.availableBalance(),
+                account.actualBalance(),
+                "Y",
+                ""
+        ));
+    }
+
+    private int toCobolDate(LocalDate date) {
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaRequestDto.java
@@ -1,0 +1,96 @@
+package com.augment.cbsa.web.creacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record CreaccCommareaRequestDto(
+        @JsonProperty("CommEyecatcher")
+        @Size(max = 4)
+        String commEyecatcher,
+
+        @JsonProperty("CommCustno")
+        @NotNull
+        @Min(0)
+        @Max(9_999_999_999L)
+        Long commCustno,
+
+        @JsonProperty("CommKey")
+        @Valid
+        @NotNull
+        CreaccKeyDto commKey,
+
+        @JsonProperty("CommAccType")
+        @NotNull
+        @Size(max = 8)
+        String commAccType,
+
+        @JsonProperty("CommIntRt")
+        @NotNull
+        @Digits(integer = 4, fraction = 2)
+        @DecimalMin("0.00")
+        @DecimalMax("9999.99")
+        BigDecimal commIntRt,
+
+        @JsonProperty("CommOpened")
+        @Min(0)
+        @Max(99_999_999)
+        Integer commOpened,
+
+        @JsonProperty("CommOverdrLim")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999)
+        Long commOverdrLim,
+
+        @JsonProperty("CommLastStmtDt")
+        @Min(0)
+        @Max(99_999_999)
+        Integer commLastStmtDt,
+
+        @JsonProperty("CommNextStmtDt")
+        @Min(0)
+        @Max(99_999_999)
+        Integer commNextStmtDt,
+
+        @JsonProperty("CommAvailBal")
+        @NotNull
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commAvailBal,
+
+        @JsonProperty("CommActBal")
+        @NotNull
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commActBal,
+
+        @JsonProperty("CommSuccess")
+        @Size(max = 1)
+        String commSuccess,
+
+        @JsonProperty("CommFailCode")
+        @Size(max = 1)
+        String commFailCode
+) {
+
+    public CreaccCommareaRequestDto {
+        Objects.requireNonNull(commCustno, "commCustno must not be null");
+        Objects.requireNonNull(commKey, "commKey must not be null");
+        Objects.requireNonNull(commAccType, "commAccType must not be null");
+        Objects.requireNonNull(commIntRt, "commIntRt must not be null");
+        Objects.requireNonNull(commOverdrLim, "commOverdrLim must not be null");
+        Objects.requireNonNull(commAvailBal, "commAvailBal must not be null");
+        Objects.requireNonNull(commActBal, "commActBal must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaResponseDto.java
@@ -1,0 +1,46 @@
+package com.augment.cbsa.web.creacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public record CreaccCommareaResponseDto(
+        @JsonProperty("CommEyecatcher")
+        String commEyecatcher,
+
+        @JsonProperty("CommCustno")
+        long commCustno,
+
+        @JsonProperty("CommKey")
+        CreaccKeyDto commKey,
+
+        @JsonProperty("CommAccType")
+        String commAccType,
+
+        @JsonProperty("CommIntRt")
+        BigDecimal commIntRt,
+
+        @JsonProperty("CommOpened")
+        int commOpened,
+
+        @JsonProperty("CommOverdrLim")
+        long commOverdrLim,
+
+        @JsonProperty("CommLastStmtDt")
+        int commLastStmtDt,
+
+        @JsonProperty("CommNextStmtDt")
+        int commNextStmtDt,
+
+        @JsonProperty("CommAvailBal")
+        BigDecimal commAvailBal,
+
+        @JsonProperty("CommActBal")
+        BigDecimal commActBal,
+
+        @JsonProperty("CommSuccess")
+        String commSuccess,
+
+        @JsonProperty("CommFailCode")
+        String commFailCode
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
@@ -1,0 +1,27 @@
+package com.augment.cbsa.web.creacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record CreaccKeyDto(
+        @JsonProperty("CommSortcode")
+        @NotNull
+        @Min(0)
+        @Max(999_999)
+        Integer commSortcode,
+
+        @JsonProperty("CommNumber")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999)
+        Long commNumber
+) {
+
+    public CreaccKeyDto {
+        Objects.requireNonNull(commSortcode, "commSortcode must not be null");
+        Objects.requireNonNull(commNumber, "commNumber must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccRequestDto.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.web.creacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record CreaccRequestDto(
+        @JsonProperty("CreAcc")
+        @Valid
+        @NotNull
+        CreaccCommareaRequestDto creAcc
+) {
+
+    public CreaccRequestDto {
+        Objects.requireNonNull(creAcc, "creAcc must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccResponseDto.java
@@ -1,0 +1,14 @@
+package com.augment.cbsa.web.creacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public record CreaccResponseDto(
+        @JsonProperty("CreAcc")
+        CreaccCommareaResponseDto creAcc
+) {
+
+    public CreaccResponseDto {
+        Objects.requireNonNull(creAcc, "creAcc must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -1,6 +1,7 @@
 package com.augment.cbsa;
 
 import com.augment.cbsa.repository.AccountRepository;
+import com.augment.cbsa.repository.CreaccRepository;
 import com.augment.cbsa.repository.CrecustRepository;
 import com.augment.cbsa.repository.CustomerRepository;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,9 @@ class CbsaApplicationTests {
 
     @MockitoBean
     private CrecustRepository crecustRepository;
+
+    @MockitoBean
+    private CreaccRepository creaccRepository;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/CreaccServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreaccServiceIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CreaccRequest;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CONTROL;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CreaccServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private CreaccService creaccService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+        dsl.update(CONTROL)
+                .set(CONTROL.CUSTOMER_COUNT, 0L)
+                .set(CONTROL.CUSTOMER_LAST, 0L)
+                .set(CONTROL.ACCOUNT_COUNT, 0L)
+                .set(CONTROL.ACCOUNT_LAST, 0L)
+                .where(CONTROL.ID.eq("GLOBAL"))
+                .execute();
+    }
+
+    @Test
+    void createsAccountAuditTrailAndControlRow() {
+        insertCustomer(10L);
+        LocalDate today = LocalDate.now(Clock.systemUTC());
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.creationSuccess()).isTrue();
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountNumber()).isEqualTo(1L);
+        assertThat(result.account().opened()).isEqualTo(today);
+        assertThat(result.account().nextStatementDate()).isEqualTo(today.plusDays(30));
+        assertThat(dsl.fetchCount(ACCOUNT)).isEqualTo(1);
+        assertThat(dsl.fetchCount(PROCTRAN)).isEqualTo(1);
+        assertThat(dsl.select(CONTROL.ACCOUNT_COUNT, CONTROL.ACCOUNT_LAST)
+                .from(CONTROL)
+                .where(CONTROL.ID.eq("GLOBAL"))
+                .fetchOne())
+                .extracting(r -> r.get(CONTROL.ACCOUNT_COUNT), r -> r.get(CONTROL.ACCOUNT_LAST))
+                .containsExactly(1L, 1L);
+        assertThat(dsl.select(PROCTRAN.DESCRIPTION).from(PROCTRAN).fetchSingle(PROCTRAN.DESCRIPTION))
+                .isEqualTo("0000000010ISA     " + today.format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy"))
+                        + today.plusDays(30).format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy")) + "      ");
+    }
+
+    @Test
+    void rejectsUnsupportedAccountTypesWithoutPersistingAnything() {
+        insertCustomer(10L);
+
+        CreaccResult result = creaccService.create(request("BONDS"));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("A");
+        assertThat(dsl.fetchCount(ACCOUNT)).isZero();
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+        assertThat(dsl.select(CONTROL.ACCOUNT_COUNT, CONTROL.ACCOUNT_LAST).from(CONTROL).where(CONTROL.ID.eq("GLOBAL")).fetchOne())
+                .extracting(r -> r.get(CONTROL.ACCOUNT_COUNT), r -> r.get(CONTROL.ACCOUNT_LAST))
+                .containsExactly(0L, 0L);
+    }
+
+    @Test
+    void rejectsCustomersWhoAlreadyHaveTenAccounts() {
+        insertCustomer(10L);
+        for (long accountNumber = 1; accountNumber <= 10; accountNumber++) {
+            insertAccount(10L, accountNumber, "ISA");
+        }
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("8");
+        assertThat(dsl.fetchCount(ACCOUNT)).isEqualTo(10);
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+    }
+
+    private CreaccRequest request(String accountType) {
+        return new CreaccRequest(10L, accountType, new BigDecimal("1.50"), 250L, new BigDecimal("1500.25"), new BigDecimal("1499.75"));
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer")
+                .set(CUSTOMER.ADDRESS, "1 Example Road")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/CreaccServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreaccServiceIntegrationTest.java
@@ -27,6 +27,9 @@ class CreaccServiceIntegrationTest extends AbstractCockroachIntegrationTest {
     @Autowired
     private CreaccService creaccService;
 
+    @Autowired
+    private Clock clock;
+
     @BeforeEach
     void cleanDatabase() {
         dsl.deleteFrom(PROCTRAN).execute();
@@ -44,7 +47,7 @@ class CreaccServiceIntegrationTest extends AbstractCockroachIntegrationTest {
     @Test
     void createsAccountAuditTrailAndControlRow() {
         insertCustomer(10L);
-        LocalDate today = LocalDate.now(Clock.systemUTC());
+        LocalDate today = LocalDate.now(clock);
 
         CreaccResult result = creaccService.create(request("ISA"));
 

--- a/src/test/java/com/augment/cbsa/service/CreaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreaccServiceUnitTest.java
@@ -1,0 +1,144 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CreaccCommand;
+import com.augment.cbsa.domain.CreaccRequest;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.repository.CreaccRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CreaccServiceUnitTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-01T10:15:30Z"), ZoneOffset.UTC);
+
+    private CreaccRepository creaccRepository;
+    private InqcustService inqcustService;
+    private InqacccuService inqacccuService;
+    private CreaccService creaccService;
+
+    @BeforeEach
+    void setUp() {
+        creaccRepository = mock(CreaccRepository.class);
+        inqcustService = mock(InqcustService.class);
+        inqacccuService = mock(InqacccuService.class);
+        creaccService = new CreaccService(creaccRepository, inqcustService, inqacccuService, "987654", FIXED_CLOCK);
+    }
+
+    @Test
+    void rejectsUnsupportedAccountTypes() {
+        CreaccResult result = creaccService.create(request("BONDS"));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("A");
+        verifyNoInteractions(inqcustService, inqacccuService, creaccRepository);
+    }
+
+    @Test
+    void returnsNotFoundWhenLinkedCustomerInquiryFails() {
+        when(inqcustService.inquire(new InqcustRequest(10L)))
+                .thenReturn(InqcustResult.failure("1", 10L, "Customer number 10 was not found."));
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.isNotFoundFailure()).isTrue();
+        assertThat(result.message()).isEqualTo("Customer number 10 was not found.");
+        verifyNoInteractions(inqacccuService, creaccRepository);
+    }
+
+    @Test
+    void returnsCountFailureWhenCustomerAccountCountCannotBeComputed() {
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer()));
+        when(inqacccuService.inquire(new InqacccuRequest(10L)))
+                .thenReturn(InqacccuResult.failure("3", 10L, true, "INQACCCU failed while fetching account data."));
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("9");
+        assertThat(result.message()).isEqualTo("INQACCCU failed while fetching account data.");
+        verifyNoInteractions(creaccRepository);
+    }
+
+    @Test
+    void returnsCapacityFailureWhenCustomerAlreadyHasTenAccounts() {
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer()));
+        when(inqacccuService.inquire(new InqacccuRequest(10L))).thenReturn(
+                InqacccuResult.success(10L, java.util.stream.LongStream.rangeClosed(1, 10)
+                        .mapToObj(this::account)
+                        .toList())
+        );
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("8");
+        verifyNoInteractions(creaccRepository);
+    }
+
+    @Test
+    void buildsCreationCommandFromValidatedInput() {
+        when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer()));
+        when(inqacccuService.inquire(new InqacccuRequest(10L))).thenReturn(InqacccuResult.success(10L, java.util.List.of()));
+        when(creaccRepository.createAccount(any())).thenAnswer(invocation -> {
+            CreaccCommand command = invocation.getArgument(0, CreaccCommand.class);
+            return CreaccResult.success(new AccountDetails(
+                    command.sortcode(),
+                    command.customerNumber(),
+                    42L,
+                    command.accountType(),
+                    command.interestRate(),
+                    command.opened(),
+                    command.overdraftLimit(),
+                    command.lastStatementDate(),
+                    command.nextStatementDate(),
+                    command.availableBalance(),
+                    command.actualBalance()
+            ));
+        });
+
+        CreaccResult result = creaccService.create(request("ISA"));
+
+        assertThat(result.creationSuccess()).isTrue();
+        ArgumentCaptor<CreaccCommand> commandCaptor = ArgumentCaptor.forClass(CreaccCommand.class);
+        verify(creaccRepository).createAccount(commandCaptor.capture());
+        CreaccCommand command = commandCaptor.getValue();
+        assertThat(command.sortcode()).isEqualTo("987654");
+        assertThat(command.customerNumber()).isEqualTo(10L);
+        assertThat(command.accountType()).isEqualTo("ISA");
+        assertThat(command.opened()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(command.lastStatementDate()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(command.nextStatementDate()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(command.transactionTime().toString()).isEqualTo("10:15:30");
+    }
+
+    private CreaccRequest request(String accountType) {
+        return new CreaccRequest(10L, accountType, new BigDecimal("1.50"), 250L, new BigDecimal("1500.25"), new BigDecimal("1499.75"));
+    }
+
+    private CustomerDetails customer() {
+        return new CustomerDetails("987654", 10L, "Example Customer", "1 Example Road", LocalDate.of(1990, 1, 1), 500, LocalDate.of(2025, 1, 1));
+    }
+
+    private AccountDetails account(long accountNumber) {
+        return new AccountDetails("987654", 10L, accountNumber, "ISA", new BigDecimal("1.50"), LocalDate.of(2024, 1, 2), new BigDecimal("250.00"), LocalDate.of(2024, 2, 3), LocalDate.of(2024, 3, 4), new BigDecimal("1500.25"), new BigDecimal("1499.75"));
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
@@ -1,0 +1,146 @@
+package com.augment.cbsa.web.creacc;
+
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CONTROL;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class CreaccControllerTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+        dsl.update(CONTROL)
+                .set(CONTROL.CUSTOMER_COUNT, 0L)
+                .set(CONTROL.CUSTOMER_LAST, 0L)
+                .set(CONTROL.ACCOUNT_COUNT, 0L)
+                .set(CONTROL.ACCOUNT_LAST, 0L)
+                .where(CONTROL.ID.eq("GLOBAL"))
+                .execute();
+    }
+
+    @Test
+    void returnsAccountForSuccessfulCreation() throws Exception {
+        insertCustomer(10L);
+        LocalDate today = LocalDate.now(Clock.systemUTC());
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.CreAcc.CommEyecatcher").value("ACCT"))
+                .andExpect(jsonPath("$.CreAcc.CommCustno").value(10))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommNumber").value(1))
+                .andExpect(jsonPath("$.CreAcc.CommOpened").value(Integer.parseInt(today.format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy")))))
+                .andExpect(jsonPath("$.CreAcc.CommNextStmtDt").value(Integer.parseInt(today.plusDays(30).format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy")))));
+
+        org.assertj.core.api.Assertions.assertThat(dsl.fetchCount(ACCOUNT)).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(dsl.fetchCount(PROCTRAN)).isEqualTo(1);
+    }
+
+    @Test
+    void returnsNotFoundWhenCustomerDoesNotExist() throws Exception {
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsConflictWhenCustomerAlreadyHasTenAccounts() throws Exception {
+        insertCustomer(10L);
+        for (long accountNumber = 1; accountNumber <= 10; accountNumber++) {
+            insertAccount(10L, accountNumber, "ISA");
+        }
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("Maximum account count reached"))
+                .andExpect(jsonPath("$.failCode").value("8"));
+    }
+
+    @Test
+    void rejectsFieldsOutsideTheCopybookRange() throws Exception {
+        insertCustomer(10L);
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 100_000_000L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer")
+                .set(CUSTOMER.ADDRESS, "1 Example Road")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+
+    private String requestJson(String accountType, long customerNumber, long overdraftLimit) {
+        return """
+                {
+                  "CreAcc": {
+                    "CommEyecatcher": "ACCT",
+                    "CommCustno": %d,
+                    "CommKey": {"CommSortcode": 0, "CommNumber": 0},
+                    "CommAccType": "%s",
+                    "CommIntRt": 1.50,
+                    "CommOpened": 0,
+                    "CommOverdrLim": %d,
+                    "CommLastStmtDt": 0,
+                    "CommNextStmtDt": 0,
+                    "CommAvailBal": 1500.25,
+                    "CommActBal": 1499.75,
+                    "CommSuccess": " ",
+                    "CommFailCode": " "
+                  }
+                }
+                """.formatted(customerNumber, accountType, overdraftLimit);
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
@@ -31,6 +31,9 @@ class CreaccControllerTest extends AbstractCockroachIntegrationTest {
     @Autowired
     private DSLContext dsl;
 
+    @Autowired
+    private Clock clock;
+
     @BeforeEach
     void cleanDatabase() {
         dsl.deleteFrom(PROCTRAN).execute();
@@ -48,7 +51,7 @@ class CreaccControllerTest extends AbstractCockroachIntegrationTest {
     @Test
     void returnsAccountForSuccessfulCreation() throws Exception {
         insertCustomer(10L);
-        LocalDate today = LocalDate.now(Clock.systemUTC());
+        LocalDate today = LocalDate.now(clock);
 
         mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
                 .andExpect(status().isOk())

--- a/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerWebMvcTest.java
@@ -1,0 +1,114 @@
+package com.augment.cbsa.web.creacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CreaccRequest;
+import com.augment.cbsa.domain.CreaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.CreaccService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CreaccController.class)
+@Import(CbsaExceptionHandler.class)
+class CreaccControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreaccService creaccService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(creaccService.create(request("ISA"))).thenReturn(CreaccResult.success(new AccountDetails(
+                "987654", 10L, 1L, "ISA", new BigDecimal("1.50"), LocalDate.of(2026, 5, 1), new BigDecimal("250.00"), LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31), new BigDecimal("1500.25"), new BigDecimal("1499.75")
+        )));
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.CreAcc.CommEyecatcher").value("ACCT"))
+                .andExpect(jsonPath("$.CreAcc.CommCustno").value(10))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommNumber").value(1));
+    }
+
+    @Test
+    void returnsProblemDetailForInvalidAccountTypes() throws Exception {
+        when(creaccService.create(request("BONDS"))).thenReturn(CreaccResult.failure("A", "Account type must be ISA, MORTGAGE, SAVING, CURRENT, or LOAN."));
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("BONDS", 10L, 250L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Invalid account type"))
+                .andExpect(jsonPath("$.failCode").value("A"));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(creaccService.create(request("ISA"))).thenReturn(CreaccResult.failure("1", "Customer number 10 was not found."));
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 100_000_000L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void redactsAbendExceptionMessageFromResponseBody() throws Exception {
+        when(creaccService.create(request("ISA"))).thenThrow(new CbsaAbendException("HWPT", "sensitive audit failure"));
+
+        mockMvc.perform(post("/api/v1/creacc/insert").contentType(APPLICATION_JSON).content(requestJson("ISA", 10L, 250L)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Service abend"))
+                .andExpect(jsonPath("$.abendCode").value("HWPT"))
+                .andExpect(content().string(not(containsString("sensitive audit failure"))));
+    }
+
+    private CreaccRequest request(String accountType) {
+        return new CreaccRequest(10L, accountType, new BigDecimal("1.50"), 250L, new BigDecimal("1500.25"), new BigDecimal("1499.75"));
+    }
+
+    private String requestJson(String accountType, long customerNumber, long overdraftLimit) {
+        return """
+                {
+                  "CreAcc": {
+                    "CommEyecatcher": "ACCT",
+                    "CommCustno": %d,
+                    "CommKey": {"CommSortcode": 0, "CommNumber": 0},
+                    "CommAccType": "%s",
+                    "CommIntRt": 1.50,
+                    "CommOpened": 0,
+                    "CommOverdrLim": %d,
+                    "CommLastStmtDt": 0,
+                    "CommNextStmtDt": 0,
+                    "CommAvailBal": 1500.25,
+                    "CommActBal": 1499.75,
+                    "CommSuccess": " ",
+                    "CommFailCode": " "
+                  }
+                }
+                """.formatted(customerNumber, accountType, overdraftLimit);
+    }
+}


### PR DESCRIPTION
Source program: https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CREACC.cbl

Mapped REST endpoints
- POST /api/v1/creacc/insert

Notable decisions
- Reused InqcustService and InqacccuService to mirror the COBOL EXEC CICS LINK validation flow before persisting the account.
- Replaced the COBOL named-counter ENQ/DEQ with a CockroachDB control row SELECT FOR UPDATE, wrapped in CrdbRetry, so account allocation is transactional and retry-safe.
- Persisted the account, control, and proctran updates in one transaction so failed writes do not leave partially-created account state behind.
- Preserved the z/OS Connect nested CreAcc JSON contract in request/response DTOs while continuing the project-wide RFC-7807 ProblemDetail error handling for failure paths.

Test coverage
- Unit: CreaccServiceUnitTest
- SpringBootTest: CreaccServiceIntegrationTest
- MockMvc: CreaccControllerTest
- Web slice: CreaccControllerWebMvcTest
