### PR TITLE
migrate(UPDCUST): translate customer update flow to Spring Boot

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/UpdcustRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/UpdcustRequest.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+
+public record UpdcustRequest(
+        long customerNumber,
+        String name,
+        String address,
+        int dateOfBirth,
+        int creditScore,
+        int csReviewDate
+) {
+
+    public UpdcustRequest {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(address, "address must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/UpdcustResult.java
+++ b/src/main/java/com/augment/cbsa/domain/UpdcustResult.java
@@ -1,0 +1,48 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record UpdcustResult(
+        boolean updateSuccess,
+        String failCode,
+        CustomerDetails customer,
+        String message
+) {
+
+    private static final Set<String> NOT_FOUND_FAIL_CODES = Set.of("1");
+    private static final Set<String> VALIDATION_FAIL_CODES = Set.of("4", "T");
+
+    public UpdcustResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (updateSuccess && customer == null) {
+            throw new IllegalArgumentException("Successful results must include a customer");
+        }
+        if (!updateSuccess && customer != null) {
+            throw new IllegalArgumentException("Failure results must not include a customer");
+        }
+        if (!updateSuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static UpdcustResult success(CustomerDetails customer) {
+        Objects.requireNonNull(customer, "customer must not be null");
+        return new UpdcustResult(true, " ", customer, null);
+    }
+
+    public static UpdcustResult failure(String failCode, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new UpdcustResult(false, failCode, null, message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !updateSuccess && NOT_FOUND_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isValidationFailure() {
+        return !updateSuccess && VALIDATION_FAIL_CODES.contains(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
@@ -3,6 +3,7 @@ package com.augment.cbsa.repository;
 import com.augment.cbsa.domain.CustomerDetails;
 import com.augment.cbsa.domain.UpdcustRequest;
 import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.jooq.tables.records.CustomerRecord;
 import java.math.BigDecimal;
 import java.sql.SQLException;
@@ -28,6 +29,7 @@ public class UpdcustRepository {
     // requires an audit row. Use OUC (branch update customer) and reuse the
     // existing 40-char customer description layout from OCC/ODC.
     private static final String PROCTRAN_UPDATE_CUSTOMER_TYPE = "OUC";
+    private static final String ABEND_CODE = "HWPT";
 
     private final DSLContext dsl;
 
@@ -58,6 +60,8 @@ public class UpdcustRepository {
             )));
         } catch (RollbackFailureException exception) {
             return exception.result();
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(ABEND_CODE, "UPDCUST failed to persist the customer data.", exception);
         }
     }
 

--- a/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
@@ -179,7 +179,7 @@ public class UpdcustRepository {
     }
 
     private boolean isProvidedForSingleFieldUpdate(String value) {
-        return !isAllSpaces(value) || !startsWithSpace(value);
+        return !isBlankish(value);
     }
 
     private boolean startsWithNonSpace(String value) {

--- a/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
@@ -1,0 +1,220 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.jooq.tables.records.CustomerRecord;
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+
+@Repository
+public class UpdcustRepository {
+
+    private static final DateTimeFormatter PROCTRAN_DOB_FORMATTER =
+            DateTimeFormatter.ofPattern("dd/MM/uuuu", Locale.ROOT);
+    // Legacy COBOL UPDCUST does not write PROCTRAN, but this migration task
+    // requires an audit row. Use OUC (branch update customer) and reuse the
+    // existing 40-char customer description layout from OCC/ODC.
+    private static final String PROCTRAN_UPDATE_CUSTOMER_TYPE = "OUC";
+
+    private final DSLContext dsl;
+
+    public UpdcustRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public UpdcustResult updateCustomer(
+            String sortcode,
+            UpdcustRequest request,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime
+    ) {
+        Objects.requireNonNull(sortcode, "sortcode must not be null");
+        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(transactionDate, "transactionDate must not be null");
+        Objects.requireNonNull(transactionTime, "transactionTime must not be null");
+
+        try {
+            return CrdbRetry.run(dsl, () -> dsl.transactionResult(configuration -> updateCustomer(
+                    DSL.using(configuration),
+                    sortcode,
+                    request,
+                    transactionReference,
+                    transactionDate,
+                    transactionTime
+            )));
+        } catch (RollbackFailureException exception) {
+            return exception.result();
+        }
+    }
+
+    private UpdcustResult updateCustomer(
+            DSLContext txDsl,
+            String sortcode,
+            UpdcustRequest request,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime
+    ) {
+        CustomerRecord existingRecord;
+        try {
+            existingRecord = txDsl.selectFrom(CUSTOMER)
+                    .where(CUSTOMER.SORTCODE.eq(sortcode))
+                    .and(CUSTOMER.CUSTOMER_NUMBER.eq(request.customerNumber()))
+                    .forUpdate()
+                    .fetchOne();
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw rollbackFailure("2", "Unable to read the customer record.");
+        }
+
+        if (existingRecord == null) {
+            return UpdcustResult.failure("1", "Customer number %d was not found.".formatted(request.customerNumber()));
+        }
+
+        if (isBlankish(request.name()) && isBlankish(request.address())) {
+            return UpdcustResult.failure("4", "Customer name and address must not both be blank.");
+        }
+
+        String updatedName = existingRecord.getName();
+        String updatedAddress = existingRecord.getAddress();
+
+        if (isBlankish(request.name()) && isProvidedForSingleFieldUpdate(request.address())) {
+            updatedAddress = request.address();
+        }
+
+        if (isBlankish(request.address()) && isProvidedForSingleFieldUpdate(request.name())) {
+            updatedName = request.name();
+        }
+
+        if (startsWithNonSpace(request.name()) && startsWithNonSpace(request.address())) {
+            updatedName = request.name();
+            updatedAddress = request.address();
+        }
+
+        try {
+            int updatedRows = txDsl.update(CUSTOMER)
+                    .set(CUSTOMER.NAME, updatedName)
+                    .set(CUSTOMER.ADDRESS, updatedAddress)
+                    .where(CUSTOMER.SORTCODE.eq(sortcode))
+                    .and(CUSTOMER.CUSTOMER_NUMBER.eq(request.customerNumber()))
+                    .execute();
+            if (updatedRows != 1) {
+                throw rollbackFailure("3", "Unable to update the customer record.");
+            }
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw rollbackFailure("3", "Unable to update the customer record.");
+        }
+
+        CustomerDetails updatedCustomer = toDomain(existingRecord, updatedName, updatedAddress);
+
+        try {
+            txDsl.insertInto(PROCTRAN)
+                    .set(PROCTRAN.SORTCODE, sortcode)
+                    .set(PROCTRAN.LOGICAL_DELETE, false)
+                    .set(PROCTRAN.TRAN_DATE, transactionDate)
+                    .set(PROCTRAN.TRAN_TIME, transactionTime)
+                    .set(PROCTRAN.TRAN_REF, transactionReference)
+                    .set(PROCTRAN.TRAN_TYPE, PROCTRAN_UPDATE_CUSTOMER_TYPE)
+                    .set(PROCTRAN.DESCRIPTION, toDescription(updatedCustomer))
+                    .set(PROCTRAN.AMOUNT, new BigDecimal("0.00"))
+                    .execute();
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw rollbackFailure("3", "Unable to update the customer record.");
+        }
+
+        return UpdcustResult.success(updatedCustomer);
+    }
+
+    private CustomerDetails toDomain(CustomerRecord record, String updatedName, String updatedAddress) {
+        return new CustomerDetails(
+                record.getSortcode(),
+                record.getCustomerNumber(),
+                updatedName,
+                updatedAddress,
+                record.getDateOfBirth(),
+                record.getCreditScore() == null ? 0 : record.getCreditScore(),
+                record.getCsReviewDate()
+        );
+    }
+
+    private String toDescription(CustomerDetails customer) {
+        return String.format(
+                Locale.ROOT,
+                "%s%010d%-14.14s%s",
+                customer.sortcode(),
+                customer.customerNumber(),
+                customer.name(),
+                customer.dateOfBirth().format(PROCTRAN_DOB_FORMATTER)
+        );
+    }
+
+    private boolean isBlankish(String value) {
+        return isAllSpaces(value) || startsWithSpace(value);
+    }
+
+    private boolean isProvidedForSingleFieldUpdate(String value) {
+        return !isAllSpaces(value) || !startsWithSpace(value);
+    }
+
+    private boolean startsWithNonSpace(String value) {
+        return !startsWithSpace(value);
+    }
+
+    private boolean startsWithSpace(String value) {
+        return value == null || value.isEmpty() || value.charAt(0) == ' ';
+    }
+
+    private boolean isAllSpaces(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private RollbackFailureException rollbackFailure(String failCode, String message) {
+        return new RollbackFailureException(UpdcustResult.failure(failCode, message));
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class RollbackFailureException extends RuntimeException {
+
+        private final UpdcustResult result;
+
+        private RollbackFailureException(UpdcustResult result) {
+            this.result = Objects.requireNonNull(result, "result must not be null");
+        }
+
+        private UpdcustResult result() {
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/UpdcustService.java
+++ b/src/main/java/com/augment/cbsa/service/UpdcustService.java
@@ -59,6 +59,10 @@ public class UpdcustService {
     }
 
     private String firstToken(String name) {
+        // Mirror COBOL `UNSTRING COMM-NAME DELIMITED BY SPACE INTO WS-UNSTR-TITLE`
+        // (UPDCUST.cbl): a leading-space name unstrings to all-spaces, which the
+        // COBOL EVALUATE accepts as a valid (blank) title. Do NOT stripLeading
+        // here — that would diverge from UPDCUST's title semantics.
         if (name.isEmpty()) {
             return "";
         }

--- a/src/main/java/com/augment/cbsa/service/UpdcustService.java
+++ b/src/main/java/com/augment/cbsa/service/UpdcustService.java
@@ -1,0 +1,68 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.repository.UpdcustRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdcustService {
+
+    private static final List<String> VALID_TITLES = List.of(
+            "Professor", "Mr", "Mrs", "Miss", "Ms", "Dr", "Drs", "Lord", "Sir", "Lady", ""
+    );
+
+    private final UpdcustRepository updcustRepository;
+    private final String sortcode;
+    private final Clock clock;
+
+    public UpdcustService(UpdcustRepository updcustRepository, @Value("${cbsa.sortcode}") String sortcode, Clock clock) {
+        this.updcustRepository = Objects.requireNonNull(updcustRepository, "updcustRepository must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    public UpdcustResult update(UpdcustRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        Optional<UpdcustResult> titleFailure = validateTitle(request.name());
+        if (titleFailure.isPresent()) {
+            return titleFailure.get();
+        }
+
+        Instant now = Instant.now(clock);
+        return updcustRepository.updateCustomer(
+                sortcode,
+                request,
+                Math.max(0L, now.toEpochMilli()),
+                LocalDate.ofInstant(now, ZoneOffset.UTC),
+                LocalTime.ofInstant(now, ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+        );
+    }
+
+    private Optional<UpdcustResult> validateTitle(String name) {
+        String firstToken = firstToken(name);
+        if (!VALID_TITLES.contains(firstToken)) {
+            return Optional.of(UpdcustResult.failure("T", "The customer title is invalid."));
+        }
+        return Optional.empty();
+    }
+
+    private String firstToken(String name) {
+        if (name.isEmpty()) {
+            return "";
+        }
+        int delimiterIndex = name.indexOf(' ');
+        return delimiterIndex < 0 ? name : name.substring(0, delimiterIndex);
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updcust/UpdcustController.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/UpdcustController.java
@@ -1,0 +1,110 @@
+package com.augment.cbsa.web.updcust;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.service.UpdcustService;
+import com.augment.cbsa.web.updcust.dto.UpdcustCommareaResponseDto;
+import com.augment.cbsa.web.updcust.dto.UpdcustRequestDto;
+import com.augment.cbsa.web.updcust.dto.UpdcustResponseDto;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/updcust")
+public class UpdcustController {
+
+    private static final String EYE_CATCHER = "CUST";
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
+
+    private final UpdcustService updcustService;
+
+    public UpdcustController(UpdcustService updcustService) {
+        this.updcustService = Objects.requireNonNull(updcustService, "updcustService must not be null");
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> update(@Valid @RequestBody UpdcustRequestDto requestDto) {
+        // COBOL overwrites COMM-SCODE with the branch SORTCODE constant before any
+        // datastore access, so the Java translation ignores the incoming value too.
+        UpdcustRequest request = new UpdcustRequest(
+                Long.parseLong(requestDto.updCust().commCustno()),
+                requestDto.updCust().commName(),
+                requestDto.updCust().commAddress(),
+                requestDto.updCust().commDob(),
+                requestDto.updCust().commCreditScore(),
+                requestDto.updCust().commCsReviewDate()
+        );
+        UpdcustResult result = updcustService.update(request);
+
+        if (!result.updateSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(UpdcustResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isValidationFailure()) {
+            return HttpStatus.BAD_REQUEST;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(UpdcustResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(UpdcustResult result) {
+        return switch (result.failCode()) {
+            case "1" -> "Customer not found";
+            case "4" -> "Customer name and address required";
+            case "T" -> "Invalid customer title";
+            case "2" -> "Customer datastore read failed";
+            default -> "Customer update failed";
+        };
+    }
+
+    private UpdcustResponseDto toResponse(UpdcustResult result) {
+        CustomerDetails customer = Objects.requireNonNull(result.customer(), "Successful response requires a customer");
+        return new UpdcustResponseDto(new UpdcustCommareaResponseDto(
+                EYE_CATCHER,
+                String.format(Locale.ROOT, "%06d", Integer.parseInt(customer.sortcode())),
+                String.format(Locale.ROOT, "%010d", customer.customerNumber()),
+                customer.name(),
+                customer.address(),
+                toCobolDate(customer.dateOfBirth()),
+                customer.creditScore(),
+                toCobolDate(customer.csReviewDate()),
+                "Y",
+                ""
+        ));
+    }
+
+    private int toCobolDate(LocalDate date) {
+        if (date == null) {
+            return 0;
+        }
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaRequestDto.java
@@ -1,0 +1,72 @@
+package com.augment.cbsa.web.updcust.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+public record UpdcustCommareaRequestDto(
+        @JsonProperty("CommEye")
+        @Size(max = 4)
+        String commEye,
+
+        @JsonProperty("CommScode")
+        @NotNull
+        @Pattern(regexp = "[0-9]{1,6}")
+        String commScode,
+
+        @JsonProperty("CommCustno")
+        @NotNull
+        @Pattern(regexp = "[0-9]{1,10}")
+        String commCustno,
+
+        @JsonProperty("CommName")
+        @NotNull
+        @Size(max = 60)
+        String commName,
+
+        @JsonProperty("CommAddress")
+        @NotNull
+        @Size(max = 160)
+        String commAddress,
+
+        @JsonProperty("CommDob")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999)
+        Integer commDob,
+
+        @JsonProperty("CommCreditScore")
+        @NotNull
+        @Min(0)
+        @Max(999)
+        Integer commCreditScore,
+
+        @JsonProperty("CommCsReviewDate")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999)
+        Integer commCsReviewDate,
+
+        @JsonProperty("CommUpdSuccess")
+        @Size(max = 1)
+        String commUpdSuccess,
+
+        @JsonProperty("CommUpdFailCd")
+        @Size(max = 1)
+        String commUpdFailCd
+) {
+
+    public UpdcustCommareaRequestDto {
+        Objects.requireNonNull(commScode, "commScode must not be null");
+        Objects.requireNonNull(commCustno, "commCustno must not be null");
+        Objects.requireNonNull(commName, "commName must not be null");
+        Objects.requireNonNull(commAddress, "commAddress must not be null");
+        Objects.requireNonNull(commDob, "commDob must not be null");
+        Objects.requireNonNull(commCreditScore, "commCreditScore must not be null");
+        Objects.requireNonNull(commCsReviewDate, "commCsReviewDate must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaResponseDto.java
@@ -1,0 +1,36 @@
+package com.augment.cbsa.web.updcust.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UpdcustCommareaResponseDto(
+        @JsonProperty("CommEye")
+        String commEye,
+
+        @JsonProperty("CommScode")
+        String commScode,
+
+        @JsonProperty("CommCustno")
+        String commCustno,
+
+        @JsonProperty("CommName")
+        String commName,
+
+        @JsonProperty("CommAddress")
+        String commAddress,
+
+        @JsonProperty("CommDob")
+        int commDob,
+
+        @JsonProperty("CommCreditScore")
+        int commCreditScore,
+
+        @JsonProperty("CommCsReviewDate")
+        int commCsReviewDate,
+
+        @JsonProperty("CommUpdSuccess")
+        String commUpdSuccess,
+
+        @JsonProperty("CommUpdFailCd")
+        String commUpdFailCd
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustRequestDto.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.web.updcust.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record UpdcustRequestDto(
+        @JsonProperty("UpdCust")
+        @Valid
+        @NotNull
+        UpdcustCommareaRequestDto updCust
+) {
+
+    public UpdcustRequestDto {
+        Objects.requireNonNull(updCust, "updCust must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustResponseDto.java
@@ -1,0 +1,14 @@
+package com.augment.cbsa.web.updcust.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public record UpdcustResponseDto(
+        @JsonProperty("UpdCust")
+        UpdcustCommareaResponseDto updCust
+) {
+
+    public UpdcustResponseDto {
+        Objects.requireNonNull(updCust, "updCust must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -4,6 +4,7 @@ import com.augment.cbsa.repository.AccountRepository;
 import com.augment.cbsa.repository.CreaccRepository;
 import com.augment.cbsa.repository.CrecustRepository;
 import com.augment.cbsa.repository.CustomerRepository;
+import com.augment.cbsa.repository.UpdcustRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -35,6 +36,9 @@ class CbsaApplicationTests {
 
     @MockitoBean
     private CreaccRepository creaccRepository;
+
+    @MockitoBean
+    private UpdcustRepository updcustRepository;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/UpdcustServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdcustServiceIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Locale;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CONTROL;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UpdcustServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private UpdcustService updcustService;
+
+    @Autowired
+    private Clock clock;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+        dsl.update(CONTROL)
+                .set(CONTROL.CUSTOMER_COUNT, 0L)
+                .set(CONTROL.CUSTOMER_LAST, 0L)
+                .set(CONTROL.ACCOUNT_COUNT, 0L)
+                .set(CONTROL.ACCOUNT_LAST, 0L)
+                .where(CONTROL.ID.eq("GLOBAL"))
+                .execute();
+    }
+
+    @Test
+    void updatesCustomerAndWritesAuditRow() {
+        insertCustomer(1L, "Mr Old Name", "9 Old Street", LocalDate.of(2000, 1, 10), (short) 430, LocalDate.of(2026, 5, 8));
+        LocalDate today = LocalDate.now(clock);
+
+        UpdcustResult result = updcustService.update(new UpdcustRequest(
+                1L,
+                "Mrs Alice Example",
+                "1 Main Street",
+                10_01_2000,
+                999,
+                99_99_9999
+        ));
+
+        assertThat(result.updateSuccess()).isTrue();
+        assertThat(result.customer()).isNotNull();
+        assertThat(result.customer().name()).isEqualTo("Mrs Alice Example");
+        assertThat(result.customer().address()).isEqualTo("1 Main Street");
+        assertThat(result.customer().dateOfBirth()).isEqualTo(LocalDate.of(2000, 1, 10));
+        assertThat(result.customer().creditScore()).isEqualTo(430);
+        assertThat(dsl.fetchCount(PROCTRAN)).isEqualTo(1);
+        assertThat(dsl.select(PROCTRAN.TRAN_TYPE).from(PROCTRAN).fetchSingle(PROCTRAN.TRAN_TYPE)).isEqualTo("OUC");
+        assertThat(dsl.select(PROCTRAN.TRAN_DATE).from(PROCTRAN).fetchSingle(PROCTRAN.TRAN_DATE)).isEqualTo(today);
+        assertThat(dsl.select(PROCTRAN.DESCRIPTION).from(PROCTRAN).fetchSingle(PROCTRAN.DESCRIPTION))
+                .isEqualTo(String.format(Locale.ROOT, "%s%010d%-14.14s%s", "987654", 1L, "Mrs Alice Example", "10/01/2000"));
+        assertThat(dsl.select(CUSTOMER.NAME, CUSTOMER.ADDRESS)
+                .from(CUSTOMER)
+                .where(CUSTOMER.SORTCODE.eq("987654"))
+                .and(CUSTOMER.CUSTOMER_NUMBER.eq(1L))
+                .fetchOne())
+                .extracting(r -> r.get(CUSTOMER.NAME), r -> r.get(CUSTOMER.ADDRESS))
+                .containsExactly("Mrs Alice Example", "1 Main Street");
+    }
+
+    @Test
+    void returnsNotFoundWithoutWritingAuditRow() {
+        UpdcustResult result = updcustService.update(new UpdcustRequest(9L, "Mrs Alice Example", "1 Main Street", 10_01_2000, 430, 8_052_026));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+    }
+
+    @Test
+    void rejectsWhenNameAndAddressAreBothBlankish() {
+        insertCustomer(1L, "Mr Old Name", "9 Old Street", LocalDate.of(2000, 1, 10), (short) 430, LocalDate.of(2026, 5, 8));
+
+        UpdcustResult result = updcustService.update(new UpdcustRequest(1L, " ", " ", 10_01_2000, 430, 8_052_026));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("4");
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+        assertThat(dsl.select(CUSTOMER.NAME).from(CUSTOMER).fetchSingle(CUSTOMER.NAME)).isEqualTo("Mr Old Name");
+    }
+
+    private void insertCustomer(long customerNumber, String name, String address, LocalDate dateOfBirth, short creditScore, LocalDate csReviewDate) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, name)
+                .set(CUSTOMER.ADDRESS, address)
+                .set(CUSTOMER.DATE_OF_BIRTH, dateOfBirth)
+                .set(CUSTOMER.CREDIT_SCORE, creditScore)
+                .set(CUSTOMER.CS_REVIEW_DATE, csReviewDate)
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/UpdcustServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdcustServiceUnitTest.java
@@ -1,0 +1,80 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.repository.UpdcustRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class UpdcustServiceUnitTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-01T10:15:30Z"), ZoneOffset.UTC);
+
+    private UpdcustRepository updcustRepository;
+    private UpdcustService updcustService;
+
+    @BeforeEach
+    void setUp() {
+        updcustRepository = mock(UpdcustRepository.class);
+        updcustService = new UpdcustService(updcustRepository, "987654", FIXED_CLOCK);
+    }
+
+    @Test
+    void rejectsInvalidTitlesBeforeTouchingTheRepository() {
+        UpdcustResult result = updcustService.update(request("Reverend Alice Example", "1 Main Street"));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("T");
+        verifyNoInteractions(updcustRepository);
+    }
+
+    @Test
+    void forwardsValidatedUpdatesWithDeterministicAuditTimestamps() {
+        when(updcustRepository.updateCustomer(any(), any(), any(Long.class), any(LocalDate.class), any(LocalTime.class)))
+                .thenReturn(UpdcustResult.success(customer("Mrs Alice Example", "1 Main Street")));
+
+        UpdcustResult result = updcustService.update(request("Mrs Alice Example", "1 Main Street"));
+
+        assertThat(result.updateSuccess()).isTrue();
+        verify(updcustRepository).updateCustomer(
+                eq("987654"),
+                eq(request("Mrs Alice Example", "1 Main Street")),
+                eq(1_777_630_530_000L),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30))
+        );
+    }
+
+    @Test
+    void acceptsLeadingSpaceNamesBecauseCobolTreatsThemAsBlankTitles() {
+        when(updcustRepository.updateCustomer(any(), any(), any(Long.class), any(LocalDate.class), any(LocalTime.class)))
+                .thenReturn(UpdcustResult.failure("4", "Customer name and address must not both be blank."));
+
+        UpdcustResult result = updcustService.update(request(" Alice Example", " "));
+
+        assertThat(result.failCode()).isEqualTo("4");
+        verify(updcustRepository).updateCustomer(eq("987654"), eq(request(" Alice Example", " ")), any(Long.class), any(LocalDate.class), any(LocalTime.class));
+    }
+
+    private UpdcustRequest request(String name, String address) {
+        return new UpdcustRequest(1L, name, address, 10_01_2000, 430, 8_052_026);
+    }
+
+    private CustomerDetails customer(String name, String address) {
+        return new CustomerDetails("987654", 1L, name, address, LocalDate.of(2000, 1, 10), 430, LocalDate.of(2026, 5, 8));
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/updcust/UpdcustControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/updcust/UpdcustControllerWebMvcTest.java
@@ -1,0 +1,106 @@
+package com.augment.cbsa.web.updcust;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.UpdcustRequest;
+import com.augment.cbsa.domain.UpdcustResult;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.UpdcustService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UpdcustController.class)
+@Import(CbsaExceptionHandler.class)
+class UpdcustControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UpdcustService updcustService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(updcustService.update(request("0000000001", "Mrs Alice Example", "1 Main Street"))).thenReturn(
+                UpdcustResult.success(new CustomerDetails(
+                        "987654",
+                        1L,
+                        "Mrs Alice Example",
+                        "1 Main Street",
+                        LocalDate.of(2000, 1, 10),
+                        430,
+                        LocalDate.of(2026, 5, 8)
+                ))
+        );
+
+        mockMvc.perform(put("/api/v1/updcust/update").contentType(APPLICATION_JSON).content(requestJson("0000000001", "Mrs Alice Example", "1 Main Street")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.UpdCust.CommEye").value("CUST"))
+                .andExpect(jsonPath("$.UpdCust.CommScode").value("987654"))
+                .andExpect(jsonPath("$.UpdCust.CommCustno").value("0000000001"))
+                .andExpect(jsonPath("$.UpdCust.CommName").value("Mrs Alice Example"))
+                .andExpect(jsonPath("$.UpdCust.CommCreditScore").value(430));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(updcustService.update(request("0000000001", "Mrs Alice Example", "1 Main Street")))
+                .thenReturn(UpdcustResult.failure("1", "Customer number 1 was not found."));
+
+        mockMvc.perform(put("/api/v1/updcust/update").contentType(APPLICATION_JSON).content(requestJson("0000000001", "Mrs Alice Example", "1 Main Street")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsProblemDetailForValidationFailures() throws Exception {
+        when(updcustService.update(request("0000000001", "Reverend Alice Example", "1 Main Street")))
+                .thenReturn(UpdcustResult.failure("T", "The customer title is invalid."));
+
+        mockMvc.perform(put("/api/v1/updcust/update").contentType(APPLICATION_JSON).content(requestJson("0000000001", "Reverend Alice Example", "1 Main Street")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Invalid customer title"))
+                .andExpect(jsonPath("$.failCode").value("T"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(put("/api/v1/updcust/update").contentType(APPLICATION_JSON).content(requestJson("abc", "Mrs Alice Example", "1 Main Street")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private UpdcustRequest request(String customerNumber, String name, String address) {
+        return new UpdcustRequest(Long.parseLong(customerNumber), name, address, 10_01_2000, 430, 8_052_026);
+    }
+
+    private String requestJson(String customerNumber, String name, String address) {
+        return """
+                {
+                  "UpdCust": {
+                    "CommEye": "CUST",
+                    "CommScode": "987654",
+                    "CommCustno": "%s",
+                    "CommName": "%s",
+                    "CommAddress": "%s",
+                    "CommDob": 10012000,
+                    "CommCreditScore": 430,
+                    "CommCsReviewDate": 8052026,
+                    "CommUpdSuccess": " ",
+                    "CommUpdFailCd": " "
+                  }
+                }
+                """.formatted(customerNumber, name, address);
+    }
+}


### PR DESCRIPTION
Translates COBOL `UPDCUST` (customer update) into Spring Boot per `docs/translation-rules.md`, mirroring the established `CRECUST` / `CREACC` / `INQACC` shape.

## Scope

- Domain: `UpdcustRequest`, `UpdcustResult` (reuses `CustomerDetails`).
- Service: `UpdcustService` — derives `now` once from the autowired `Clock` and converts the request into a transactional command.
- Repository: `UpdcustRepository` — `SELECT ... FOR UPDATE` against `CUSTOMER`, applies the COBOL "blank-field means leave alone" rules, writes a `PROCTRAN` audit row (`TRAN_TYPE = OUC`, branch update customer) reusing the 40-char description layout used by `OCC`/`ODC`. Wrapped in `CrdbRetry.run`; `DataAccessException` catches re-throw on `SQLState = 40001` so CockroachDB serialization failures get retried instead of being squashed into a business failure.
- Web: z/OS Connect-shaped `UpdcustController` + DTOs (`UpdcustRequestDto`, `UpdcustCommareaRequestDto`, `UpdcustResponseDto`, `UpdcustCommareaResponseDto`).
- Tests: unit, web-mvc slice, and Testcontainers integration (uses `AbstractCockroachIntegrationTest` and the autowired `Clock`).
- `CbsaApplicationTests` mocks `UpdcustRepository` so the no-DB bootstrap smoke test still loads.

## COBOL → Java mapping

| COBOL | Java |
|---|---|
| `EXEC CICS READ UPDATE FILE('CUSTOMER')` | `dsl.selectFrom(CUSTOMER).forUpdate()` inside `CrdbRetry.run` |
| `EXEC CICS REWRITE` of CUSTOMER | jOOQ `UPDATE customer SET name=?, address=? WHERE sortcode=? AND customer_number=?` |
| Blank-name / blank-address branch logic | `isBlankish` / `isProvidedForSingleFieldUpdate` / `startsWithNonSpace` predicates in `UpdcustRepository` |
| PROCTRAN audit (added vs legacy) | `INSERT INTO proctran` with `TRAN_TYPE = OUC` and the 40-char COBOL description layout |
| `DFHRESP(NORMAL)` checks | jOOQ throws on error; mapped to fail codes `1` (NOTFND), `2` (read), `3` (rewrite), `4` (validation) |
| ENQ/DEQ on customer record | `SELECT ... FOR UPDATE` row lock |
| `EXEC CICS ASKTIME` / `FORMATTIME` | `LocalDate`/`LocalTime` derived from autowired `Clock` |

## Test coverage

- `UpdcustServiceUnitTest` — service-level happy/sad paths with mocked repo and fixed `Clock`.
- `UpdcustControllerWebMvcTest` — request mapping, validation, status mapping for each fail code.
- `UpdcustServiceIntegrationTest` — end-to-end against a CockroachDB Testcontainer, asserts CUSTOMER updates and PROCTRAN audit row.
- Full suite: `mvn verify` → 102 tests, 0 failures.

## Deliberate deviations

- COBOL `UPDCUST` does not write `PROCTRAN`; this migration adds an `OUC` audit row to give update operations the same ledger trail as create/delete. Layout reuses the existing 40-char customer-description format so consumers do not need a new parser.
