### PR TITLE
migrate(UPDACC): translate UPDACC to Java

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/UpdaccRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/UpdaccRequest.java
@@ -1,0 +1,17 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record UpdaccRequest(
+        long accountNumber,
+        String accountType,
+        BigDecimal interestRate,
+        long overdraftLimit
+) {
+
+    public UpdaccRequest {
+        Objects.requireNonNull(accountType, "accountType must not be null");
+        Objects.requireNonNull(interestRate, "interestRate must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/UpdaccResult.java
+++ b/src/main/java/com/augment/cbsa/domain/UpdaccResult.java
@@ -1,0 +1,48 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record UpdaccResult(
+        boolean updateSuccess,
+        String failCode,
+        AccountDetails account,
+        String message
+) {
+
+    private static final Set<String> NOT_FOUND_FAIL_CODES = Set.of("1");
+    private static final Set<String> VALIDATION_FAIL_CODES = Set.of("2");
+
+    public UpdaccResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (updateSuccess && account == null) {
+            throw new IllegalArgumentException("Successful results must include an account");
+        }
+        if (!updateSuccess && account != null) {
+            throw new IllegalArgumentException("Failure results must not include an account");
+        }
+        if (!updateSuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static UpdaccResult success(AccountDetails account) {
+        Objects.requireNonNull(account, "account must not be null");
+        return new UpdaccResult(true, " ", account, null);
+    }
+
+    public static UpdaccResult failure(String failCode, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new UpdaccResult(false, failCode, null, message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !updateSuccess && NOT_FOUND_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isValidationFailure() {
+        return !updateSuccess && VALIDATION_FAIL_CODES.contains(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/UpdaccRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdaccRepository.java
@@ -1,0 +1,112 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.jooq.tables.records.AccountRecord;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.SQLException;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+
+@Repository
+public class UpdaccRepository {
+
+    private static final String READ_ABEND_CODE = "HRAC";
+    private static final String UPDATE_ABEND_CODE = "HUAC";
+
+    private final DSLContext dsl;
+
+    public UpdaccRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public UpdaccResult updateAccount(String sortcode, UpdaccRequest request) {
+        Objects.requireNonNull(sortcode, "sortcode must not be null");
+        Objects.requireNonNull(request, "request must not be null");
+
+        try {
+            return CrdbRetry.run(
+                    dsl,
+                    () -> dsl.transactionResult(configuration -> updateAccount(DSL.using(configuration), sortcode, request))
+            );
+        } catch (CbsaAbendException exception) {
+            throw exception;
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(UPDATE_ABEND_CODE, "UPDACC failed to persist the account data.", exception);
+        }
+    }
+
+    private UpdaccResult updateAccount(DSLContext txDsl, String sortcode, UpdaccRequest request) {
+        AccountRecord existingRecord;
+        try {
+            existingRecord = txDsl.selectFrom(ACCOUNT)
+                    .where(ACCOUNT.SORTCODE.eq(sortcode))
+                    .and(ACCOUNT.ACCOUNT_NUMBER.eq(request.accountNumber()))
+                    .forUpdate()
+                    .fetchOne();
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(READ_ABEND_CODE, "UPDACC failed to read the account data.", exception);
+        }
+
+        if (existingRecord == null) {
+            return UpdaccResult.failure("1", "Account number %d was not found.".formatted(request.accountNumber()));
+        }
+
+        BigDecimal interestRate = request.interestRate().setScale(2, RoundingMode.HALF_EVEN);
+        BigDecimal overdraftLimit = BigDecimal.valueOf(request.overdraftLimit()).setScale(2, RoundingMode.HALF_EVEN);
+
+        try {
+            int updatedRows = txDsl.update(ACCOUNT)
+                    .set(ACCOUNT.ACCOUNT_TYPE, request.accountType())
+                    .set(ACCOUNT.INTEREST_RATE, interestRate)
+                    .set(ACCOUNT.OVERDRAFT_LIMIT, overdraftLimit)
+                    .where(ACCOUNT.SORTCODE.eq(sortcode))
+                    .and(ACCOUNT.ACCOUNT_NUMBER.eq(request.accountNumber()))
+                    .execute();
+            if (updatedRows != 1) {
+                throw new CbsaAbendException(UPDATE_ABEND_CODE, "UPDACC failed to update the account data.");
+            }
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(UPDATE_ABEND_CODE, "UPDACC failed to update the account data.", exception);
+        }
+
+        return UpdaccResult.success(new AccountDetails(
+                existingRecord.getSortcode(),
+                existingRecord.getCustomerNumber(),
+                existingRecord.getAccountNumber(),
+                request.accountType(),
+                interestRate,
+                existingRecord.getOpened(),
+                overdraftLimit,
+                existingRecord.getLastStmtDate(),
+                existingRecord.getNextStmtDate(),
+                existingRecord.getAvailableBalance(),
+                existingRecord.getActualBalance()
+        ));
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/UpdaccService.java
+++ b/src/main/java/com/augment/cbsa/service/UpdaccService.java
@@ -1,0 +1,34 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.repository.UpdaccRepository;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdaccService {
+
+    private final UpdaccRepository updaccRepository;
+    private final String sortcode;
+
+    public UpdaccService(UpdaccRepository updaccRepository, @Value("${cbsa.sortcode}") String sortcode) {
+        this.updaccRepository = Objects.requireNonNull(updaccRepository, "updaccRepository must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+    }
+
+    public UpdaccResult update(UpdaccRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        if (isInvalidAccountType(request.accountType())) {
+            return UpdaccResult.failure("2", "Account type must not be blank or start with a space.");
+        }
+
+        return updaccRepository.updateAccount(sortcode, request);
+    }
+
+    private boolean isInvalidAccountType(String accountType) {
+        return accountType.isBlank() || accountType.charAt(0) == ' ';
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updacc/UpdaccController.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/UpdaccController.java
@@ -1,0 +1,109 @@
+package com.augment.cbsa.web.updacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.service.UpdaccService;
+import com.augment.cbsa.web.updacc.dto.UpdaccCommareaResponseDto;
+import com.augment.cbsa.web.updacc.dto.UpdaccRequestDto;
+import com.augment.cbsa.web.updacc.dto.UpdaccResponseDto;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/updacc")
+public class UpdaccController {
+
+    private static final String EYE_CATCHER = "ACCT";
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
+
+    private final UpdaccService updaccService;
+
+    public UpdaccController(UpdaccService updaccService) {
+        this.updaccService = Objects.requireNonNull(updaccService, "updaccService must not be null");
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> update(@Valid @RequestBody UpdaccRequestDto requestDto) {
+        UpdaccRequest request = new UpdaccRequest(
+                requestDto.updAcc().commAccno(),
+                requestDto.updAcc().commAccType(),
+                requestDto.updAcc().commIntRate(),
+                requestDto.updAcc().commOverdraft()
+        );
+        UpdaccResult result = updaccService.update(request);
+
+        if (!result.updateSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(UpdaccResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isValidationFailure()) {
+            return HttpStatus.BAD_REQUEST;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(UpdaccResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(UpdaccResult result) {
+        if (result.isNotFoundFailure()) {
+            return "Account not found";
+        }
+        if (result.isValidationFailure()) {
+            return "Invalid account type";
+        }
+        return "Account update failed";
+    }
+
+    private UpdaccResponseDto toResponse(UpdaccResult result) {
+        AccountDetails account = Objects.requireNonNull(result.account(), "Successful response requires an account");
+        return new UpdaccResponseDto(new UpdaccCommareaResponseDto(
+                EYE_CATCHER,
+                String.format(Locale.ROOT, "%010d", account.customerNumber()),
+                account.sortcode(),
+                account.accountNumber(),
+                account.accountType(),
+                account.interestRate(),
+                toCobolDate(account.opened()),
+                account.overdraftLimit().longValueExact(),
+                toCobolDate(account.lastStatementDate()),
+                toCobolDate(account.nextStatementDate()),
+                account.availableBalance(),
+                account.actualBalance(),
+                "Y"
+        ));
+    }
+
+    private int toCobolDate(LocalDate date) {
+        if (date == null) {
+            return 0;
+        }
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaRequestDto.java
@@ -1,0 +1,78 @@
+package com.augment.cbsa.web.updacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public record UpdaccCommareaRequestDto(
+        @JsonProperty("CommEye")
+        @Size(max = 4)
+        String commEye,
+
+        @JsonProperty("CommCustno")
+        @Pattern(regexp = "[0-9]{1,10}")
+        String commCustno,
+
+        @JsonProperty("CommScode")
+        @Pattern(regexp = "[0-9]{1,6}")
+        String commScode,
+
+        @JsonProperty("CommAccno")
+        @NotNull
+        @PositiveOrZero
+        @Max(99_999_999L)
+        Long commAccno,
+
+        @JsonProperty("CommAccType")
+        @NotNull
+        @Size(max = 8)
+        String commAccType,
+
+        @JsonProperty("CommIntRate")
+        @NotNull
+        @DecimalMin("0.00")
+        @DecimalMax("9999.99")
+        BigDecimal commIntRate,
+
+        @JsonProperty("CommOpened")
+        @PositiveOrZero
+        @Max(99_999_999L)
+        Integer commOpened,
+
+        @JsonProperty("CommOverdraft")
+        @NotNull
+        @PositiveOrZero
+        @Max(99_999_999L)
+        Long commOverdraft,
+
+        @JsonProperty("CommLastStmtDt")
+        @PositiveOrZero
+        @Max(99_999_999L)
+        Integer commLastStmtDt,
+
+        @JsonProperty("CommNextStmtDt")
+        @PositiveOrZero
+        @Max(99_999_999L)
+        Integer commNextStmtDt,
+
+        @JsonProperty("CommAvailBal")
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commAvailBal,
+
+        @JsonProperty("CommActualBal")
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commActualBal,
+
+        @JsonProperty("CommSuccess")
+        @Size(max = 1)
+        String commSuccess
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaRequestDto.java
@@ -3,6 +3,7 @@ package com.augment.cbsa.web.updacc.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,6 +37,7 @@ public record UpdaccCommareaRequestDto(
 
         @JsonProperty("CommIntRate")
         @NotNull
+        @Digits(integer = 4, fraction = 2)
         @DecimalMin("0.00")
         @DecimalMax("9999.99")
         BigDecimal commIntRate,
@@ -62,11 +64,13 @@ public record UpdaccCommareaRequestDto(
         Integer commNextStmtDt,
 
         @JsonProperty("CommAvailBal")
+        @Digits(integer = 10, fraction = 2)
         @DecimalMin("-9999999999.99")
         @DecimalMax("9999999999.99")
         BigDecimal commAvailBal,
 
         @JsonProperty("CommActualBal")
+        @Digits(integer = 10, fraction = 2)
         @DecimalMin("-9999999999.99")
         @DecimalMax("9999999999.99")
         BigDecimal commActualBal,

--- a/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccCommareaResponseDto.java
@@ -1,0 +1,46 @@
+package com.augment.cbsa.web.updacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public record UpdaccCommareaResponseDto(
+        @JsonProperty("CommEye")
+        String commEye,
+
+        @JsonProperty("CommCustno")
+        String commCustno,
+
+        @JsonProperty("CommScode")
+        String commScode,
+
+        @JsonProperty("CommAccno")
+        long commAccno,
+
+        @JsonProperty("CommAccType")
+        String commAccType,
+
+        @JsonProperty("CommIntRate")
+        BigDecimal commIntRate,
+
+        @JsonProperty("CommOpened")
+        int commOpened,
+
+        @JsonProperty("CommOverdraft")
+        long commOverdraft,
+
+        @JsonProperty("CommLastStmtDt")
+        int commLastStmtDt,
+
+        @JsonProperty("CommNextStmtDt")
+        int commNextStmtDt,
+
+        @JsonProperty("CommAvailBal")
+        BigDecimal commAvailBal,
+
+        @JsonProperty("CommActualBal")
+        BigDecimal commActualBal,
+
+        @JsonProperty("CommSuccess")
+        String commSuccess
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccRequestDto.java
@@ -1,0 +1,13 @@
+package com.augment.cbsa.web.updacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdaccRequestDto(
+        @JsonProperty("UpdAcc")
+        @Valid
+        @NotNull
+        UpdaccCommareaRequestDto updAcc
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/updacc/dto/UpdaccResponseDto.java
@@ -1,0 +1,9 @@
+package com.augment.cbsa.web.updacc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UpdaccResponseDto(
+        @JsonProperty("UpdAcc")
+        UpdaccCommareaResponseDto updAcc
+) {
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -4,6 +4,7 @@ import com.augment.cbsa.repository.AccountRepository;
 import com.augment.cbsa.repository.CreaccRepository;
 import com.augment.cbsa.repository.CrecustRepository;
 import com.augment.cbsa.repository.CustomerRepository;
+import com.augment.cbsa.repository.UpdaccRepository;
 import com.augment.cbsa.repository.UpdcustRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +40,9 @@ class CbsaApplicationTests {
 
     @MockitoBean
     private UpdcustRepository updcustRepository;
+
+    @MockitoBean
+    private UpdaccRepository updaccRepository;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/UpdaccServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdaccServiceIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UpdaccServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private UpdaccService updaccService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void updatesOnlyThePermittedAccountFields() {
+        insertAccount();
+
+        UpdaccResult result = updaccService.update(new UpdaccRequest(12345678L, "MORTGAGE", new BigDecimal("2.25"), 500L));
+
+        assertThat(result.updateSuccess()).isTrue();
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountType()).isEqualTo("MORTGAGE");
+        assertThat(result.account().interestRate()).isEqualTo(new BigDecimal("2.25"));
+        assertThat(result.account().overdraftLimit()).isEqualTo(new BigDecimal("500.00"));
+        assertThat(result.account().opened()).isEqualTo(LocalDate.of(2024, 1, 2));
+        assertThat(result.account().lastStatementDate()).isEqualTo(LocalDate.of(2024, 2, 3));
+        assertThat(result.account().nextStatementDate()).isEqualTo(LocalDate.of(2024, 3, 4));
+        assertThat(result.account().availableBalance()).isEqualTo(new BigDecimal("1500.25"));
+        assertThat(result.account().actualBalance()).isEqualTo(new BigDecimal("1499.75"));
+
+        assertThat(dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchOne())
+                .satisfies(record -> {
+                    assertThat(record).isNotNull();
+                    assertThat(record.getAccountType()).isEqualTo("MORTGAGE");
+                    assertThat(record.getInterestRate()).isEqualTo(new BigDecimal("2.25"));
+                    assertThat(record.getOverdraftLimit()).isEqualTo(new BigDecimal("500.00"));
+                    assertThat(record.getLastStmtDate()).isEqualTo(LocalDate.of(2024, 2, 3));
+                    assertThat(record.getNextStmtDate()).isEqualTo(LocalDate.of(2024, 3, 4));
+                    assertThat(record.getAvailableBalance()).isEqualTo(new BigDecimal("1500.25"));
+                    assertThat(record.getActualBalance()).isEqualTo(new BigDecimal("1499.75"));
+                });
+    }
+
+    @Test
+    void returnsNotFoundWhenAccountDoesNotExist() {
+        UpdaccResult result = updaccService.update(new UpdaccRequest(12345678L, "ISA", new BigDecimal("2.25"), 500L));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("Account number 12345678 was not found.");
+    }
+
+    @Test
+    void invalidAccountTypeLeavesTheExistingRowUnchanged() {
+        insertAccount();
+
+        UpdaccResult result = updaccService.update(new UpdaccRequest(12345678L, " ISA", new BigDecimal("2.25"), 500L));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchOne())
+                .satisfies(record -> {
+                    assertThat(record).isNotNull();
+                    assertThat(record.getAccountType()).isEqualTo("ISA");
+                    assertThat(record.getInterestRate()).isEqualTo(new BigDecimal("1.50"));
+                    assertThat(record.getOverdraftLimit()).isEqualTo(new BigDecimal("250.00"));
+                });
+    }
+
+    private void insertAccount() {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, 10L)
+                .set(CUSTOMER.NAME, "Example Customer")
+                .set(CUSTOMER.ADDRESS, "1 Main Street")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, 12345678L)
+                .set(ACCOUNT.CUSTOMER_NUMBER, 10L)
+                .set(ACCOUNT.ACCOUNT_TYPE, "ISA")
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, new BigDecimal("1500.25"))
+                .set(ACCOUNT.ACTUAL_BALANCE, new BigDecimal("1499.75"))
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
@@ -1,0 +1,84 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.repository.UpdaccRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class UpdaccServiceUnitTest {
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        UpdaccRepository repository = mock(UpdaccRepository.class);
+        UpdaccService service = new UpdaccService(repository, "987654");
+
+        assertThatThrownBy(() -> service.update(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void rejectsBlankAccountTypeBeforeHittingTheRepository() {
+        UpdaccRepository repository = mock(UpdaccRepository.class);
+        UpdaccService service = new UpdaccService(repository, "987654");
+
+        UpdaccResult result = service.update(new UpdaccRequest(12345678L, "", new BigDecimal("2.25"), 500L));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(result.message()).isEqualTo("Account type must not be blank or start with a space.");
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void rejectsLeadingSpaceAccountTypeBeforeHittingTheRepository() {
+        UpdaccRepository repository = mock(UpdaccRepository.class);
+        UpdaccService service = new UpdaccService(repository, "987654");
+
+        UpdaccResult result = service.update(new UpdaccRequest(12345678L, " ISA", new BigDecimal("2.25"), 500L));
+
+        assertThat(result.updateSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void acceptsAnyNonBlankAccountTypeThatDoesNotStartWithSpace() {
+        UpdaccRepository repository = mock(UpdaccRepository.class);
+        UpdaccService service = new UpdaccService(repository, "987654");
+        UpdaccRequest request = new UpdaccRequest(12345678L, "BROKER", new BigDecimal("2.25"), 500L);
+        when(repository.updateAccount("987654", request)).thenReturn(UpdaccResult.success(account()));
+
+        UpdaccResult result = service.update(request);
+
+        assertThat(result.updateSuccess()).isTrue();
+        assertThat(result.account()).isNotNull();
+        assertThat(result.account().accountType()).isEqualTo("ISA");
+    }
+
+    private AccountDetails account() {
+        return new AccountDetails(
+                "987654",
+                10L,
+                12345678L,
+                "ISA",
+                new BigDecimal("2.25"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("500.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal("1500.25"),
+                new BigDecimal("1499.75")
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
@@ -57,21 +57,25 @@ class UpdaccServiceUnitTest {
         UpdaccRepository repository = mock(UpdaccRepository.class);
         UpdaccService service = new UpdaccService(repository, "987654");
         UpdaccRequest request = new UpdaccRequest(12345678L, "BROKER", new BigDecimal("2.25"), 500L);
-        when(repository.updateAccount("987654", request)).thenReturn(UpdaccResult.success(account()));
+        when(repository.updateAccount("987654", request)).thenReturn(UpdaccResult.success(account("BROKER")));
 
         UpdaccResult result = service.update(request);
 
         assertThat(result.updateSuccess()).isTrue();
         assertThat(result.account()).isNotNull();
-        assertThat(result.account().accountType()).isEqualTo("ISA");
+        assertThat(result.account().accountType()).isEqualTo("BROKER");
     }
 
     private AccountDetails account() {
+        return account("ISA");
+    }
+
+    private AccountDetails account(String accountType) {
         return new AccountDetails(
                 "987654",
                 10L,
                 12345678L,
-                "ISA",
+                accountType,
                 new BigDecimal("2.25"),
                 LocalDate.of(2024, 1, 2),
                 new BigDecimal("500.00"),

--- a/src/test/java/com/augment/cbsa/web/updacc/UpdaccControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/updacc/UpdaccControllerWebMvcTest.java
@@ -1,0 +1,127 @@
+package com.augment.cbsa.web.updacc;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.UpdaccRequest;
+import com.augment.cbsa.domain.UpdaccResult;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.UpdaccService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UpdaccController.class)
+@Import(CbsaExceptionHandler.class)
+class UpdaccControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UpdaccService updaccService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(updaccService.update(request("MORTGAGE"))).thenReturn(UpdaccResult.success(new AccountDetails(
+                "987654",
+                1L,
+                12345678L,
+                "MORTGAGE",
+                new BigDecimal("2.25"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("500.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal("1500.25"),
+                new BigDecimal("1499.75")
+        )));
+
+        mockMvc.perform(put("/api/v1/updacc/update").contentType(APPLICATION_JSON).content(requestJson("MORTGAGE")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.UpdAcc.CommEye").value("ACCT"))
+                .andExpect(jsonPath("$.UpdAcc.CommCustno").value("0000000001"))
+                .andExpect(jsonPath("$.UpdAcc.CommScode").value("987654"))
+                .andExpect(jsonPath("$.UpdAcc.CommAccno").value(12345678))
+                .andExpect(jsonPath("$.UpdAcc.CommAccType").value("MORTGAGE"))
+                .andExpect(jsonPath("$.UpdAcc.CommIntRate").value(2.25))
+                .andExpect(jsonPath("$.UpdAcc.CommOverdraft").value(500))
+                .andExpect(jsonPath("$.UpdAcc.CommSuccess").value("Y"));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(updaccService.update(request("MORTGAGE")))
+                .thenReturn(UpdaccResult.failure("1", "Account number 12345678 was not found."));
+
+        mockMvc.perform(put("/api/v1/updacc/update").contentType(APPLICATION_JSON).content(requestJson("MORTGAGE")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Account not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsProblemDetailForValidationFailures() throws Exception {
+        when(updaccService.update(request(" ISA")))
+                .thenReturn(UpdaccResult.failure("2", "Account type must not be blank or start with a space."));
+
+        mockMvc.perform(put("/api/v1/updacc/update").contentType(APPLICATION_JSON).content(requestJson(" ISA")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Invalid account type"))
+                .andExpect(jsonPath("$.failCode").value("2"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(put("/api/v1/updacc/update").contentType(APPLICATION_JSON).content(missingAccountNumberJson()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private UpdaccRequest request(String accountType) {
+        return new UpdaccRequest(12345678L, accountType, new BigDecimal("2.25"), 500L);
+    }
+
+    private String requestJson(String accountType) {
+        return """
+                {
+                  "UpdAcc": {
+                    "CommEye": "ACCT",
+                    "CommCustno": "0000000001",
+                    "CommScode": "987654",
+                    "CommAccno": 12345678,
+                    "CommAccType": "%s",
+                    "CommIntRate": 2.25,
+                    "CommOpened": 2012024,
+                    "CommOverdraft": 500,
+                    "CommLastStmtDt": 3022024,
+                    "CommNextStmtDt": 4032024,
+                    "CommAvailBal": 1500.25,
+                    "CommActualBal": 1499.75,
+                    "CommSuccess": " "
+                  }
+                }
+                """.formatted(accountType);
+    }
+
+    private String missingAccountNumberJson() {
+        return """
+                {
+                  "UpdAcc": {
+                    "CommAccType": "MORTGAGE",
+                    "CommIntRate": 2.25,
+                    "CommOverdraft": 500
+                  }
+                }
+                """;
+    }
+}


### PR DESCRIPTION
**Source program**: https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/UPDACC.cbl

**Mapped REST endpoints**
- `PUT /api/v1/updacc/update`

**Notable decisions**
- Preserved the COBOL SQL behavior exactly: only `accountType`, `interestRate`, and `overdraftLimit` are updated; incoming last/next statement dates and balances are ignored and the stored values are returned unchanged.
- Mirrored the COBOL validation guard for `COMM-ACC-TYPE`: reject blank values and values whose first character is a space, but allow any other non-blank 8-byte account type.
- Ignored the incoming sort code just like COBOL, which overwrites `COMM-SCODE` with the configured branch sortcode before reading the account.
- Returned HTTP 404 when the target account does not exist, while wrapping datastore read/update failures in typed `CbsaAbendException`s (`HRAC` for read, `HUAC` for update).

**Test coverage**
- Unit: `UpdaccServiceUnitTest`
- `@SpringBootTest`: `UpdaccServiceIntegrationTest`
- MockMvc: `UpdaccControllerWebMvcTest`
