### PR TITLE
migrate(DELCUS): translate DELCUS to Java

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/DelcusRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/DelcusRequest.java
@@ -1,0 +1,4 @@
+package com.augment.cbsa.domain;
+
+public record DelcusRequest(long customerNumber) {
+}

--- a/src/main/java/com/augment/cbsa/domain/DelcusResult.java
+++ b/src/main/java/com/augment/cbsa/domain/DelcusResult.java
@@ -1,0 +1,45 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+
+public record DelcusResult(
+        boolean deleteSuccess,
+        String failCode,
+        long customerNumber,
+        CustomerDetails customer,
+        String message
+) {
+
+    public DelcusResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (deleteSuccess && customer == null) {
+            throw new IllegalArgumentException("Successful results must include a customer");
+        }
+        if (!deleteSuccess && customer != null) {
+            throw new IllegalArgumentException("Failure results must not include a customer");
+        }
+        if (!deleteSuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static DelcusResult success(CustomerDetails customer) {
+        Objects.requireNonNull(customer, "customer must not be null");
+        return new DelcusResult(true, " ", customer.customerNumber(), customer, null);
+    }
+
+    public static DelcusResult failure(String failCode, long customerNumber, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new DelcusResult(false, failCode, customerNumber, null, message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !deleteSuccess && "1".equals(failCode);
+    }
+
+    public boolean isRandomRetryExhaustedFailure() {
+        return !deleteSuccess && "R".equals(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/DelcusRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/DelcusRepository.java
@@ -1,0 +1,109 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CustomerDetails;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+
+@Repository
+public class DelcusRepository {
+
+    private static final DateTimeFormatter ACCOUNT_AUDIT_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
+    private static final DateTimeFormatter CUSTOMER_AUDIT_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ROOT);
+
+    private final DSLContext dsl;
+
+    public DelcusRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public int deleteAccount(String sortcode, long accountNumber) {
+        return dsl.deleteFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .execute();
+    }
+
+    public void insertAccountDeletionAudit(
+            AccountDetails account,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime
+    ) {
+        Objects.requireNonNull(account, "account must not be null");
+        Objects.requireNonNull(transactionDate, "transactionDate must not be null");
+        Objects.requireNonNull(transactionTime, "transactionTime must not be null");
+
+        dsl.insertInto(PROCTRAN)
+                .set(PROCTRAN.SORTCODE, account.sortcode())
+                .set(PROCTRAN.LOGICAL_DELETE, false)
+                .set(PROCTRAN.TRAN_DATE, transactionDate)
+                .set(PROCTRAN.TRAN_TIME, transactionTime)
+                .set(PROCTRAN.TRAN_REF, transactionReference)
+                .set(PROCTRAN.TRAN_TYPE, "ODA")
+                .set(PROCTRAN.DESCRIPTION, toAccountDeletionDescription(account))
+                .set(PROCTRAN.AMOUNT, account.actualBalance())
+                .execute();
+    }
+
+    public int deleteCustomer(String sortcode, long customerNumber) {
+        return dsl.deleteFrom(CUSTOMER)
+                .where(CUSTOMER.SORTCODE.eq(sortcode))
+                .and(CUSTOMER.CUSTOMER_NUMBER.eq(customerNumber))
+                .execute();
+    }
+
+    public void insertCustomerDeletionAudit(
+            CustomerDetails customer,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime
+    ) {
+        Objects.requireNonNull(customer, "customer must not be null");
+        Objects.requireNonNull(transactionDate, "transactionDate must not be null");
+        Objects.requireNonNull(transactionTime, "transactionTime must not be null");
+
+        dsl.insertInto(PROCTRAN)
+                .set(PROCTRAN.SORTCODE, customer.sortcode())
+                .set(PROCTRAN.LOGICAL_DELETE, false)
+                .set(PROCTRAN.TRAN_DATE, transactionDate)
+                .set(PROCTRAN.TRAN_TIME, transactionTime)
+                .set(PROCTRAN.TRAN_REF, transactionReference)
+                .set(PROCTRAN.TRAN_TYPE, "ODC")
+                .set(PROCTRAN.DESCRIPTION, toCustomerDeletionDescription(customer))
+                .set(PROCTRAN.AMOUNT, BigDecimal.ZERO.setScale(2))
+                .execute();
+    }
+
+    private String toAccountDeletionDescription(AccountDetails account) {
+        return String.format(
+                Locale.ROOT,
+                "%010d%-8.8s%s%sDELETE",
+                account.customerNumber(),
+                account.accountType(),
+                toCobolDate(account.lastStatementDate()),
+                toCobolDate(account.nextStatementDate())
+        );
+    }
+
+    private String toCustomerDeletionDescription(CustomerDetails customer) {
+        return customer.sortcode()
+                + String.format(Locale.ROOT, "%010d", customer.customerNumber())
+                + String.format(Locale.ROOT, "%-14.14s", customer.name())
+                + customer.dateOfBirth().format(CUSTOMER_AUDIT_DATE_FORMATTER);
+    }
+
+    private String toCobolDate(LocalDate date) {
+        return date == null ? "00000000" : date.format(ACCOUNT_AUDIT_DATE_FORMATTER);
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/DelcusService.java
+++ b/src/main/java/com/augment/cbsa/service/DelcusService.java
@@ -58,6 +58,14 @@ public class DelcusService {
     public DelcusResult delete(DelcusRequest request) {
         Objects.requireNonNull(request, "request must not be null");
 
+        // INQCUST treats customerNumber=0 as "random customer"; deleting against
+        // that path is unsafe, so reject it explicitly at the service boundary
+        // independent of any controller-level path validation.
+        if (request.customerNumber() <= 0L) {
+            return DelcusResult.failure("1", request.customerNumber(),
+                    "Customer number %d is invalid.".formatted(request.customerNumber()));
+        }
+
         return CrdbRetry.run(dsl, () -> transactionTemplate.execute(status -> deleteWithinTransaction(request)));
     }
 

--- a/src/main/java/com/augment/cbsa/service/DelcusService.java
+++ b/src/main/java/com/augment/cbsa/service/DelcusService.java
@@ -1,0 +1,161 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.DelcusRequest;
+import com.augment.cbsa.domain.DelcusResult;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.CrdbRetry;
+import com.augment.cbsa.repository.DelcusRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class DelcusService {
+
+    private static final String ACCOUNT_INQUIRY_ABEND_CODE = "WPV6";
+    private static final String DELETE_ABEND_CODE = "WPV7";
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
+
+    private final InqcustService inqcustService;
+    private final InqacccuService inqacccuService;
+    private final DelcusRepository delcusRepository;
+    private final DSLContext dsl;
+    private final TransactionTemplate transactionTemplate;
+    private final Clock clock;
+
+    public DelcusService(
+            InqcustService inqcustService,
+            InqacccuService inqacccuService,
+            DelcusRepository delcusRepository,
+            DSLContext dsl,
+            TransactionTemplate transactionTemplate,
+            Clock clock
+    ) {
+        this.inqcustService = Objects.requireNonNull(inqcustService, "inqcustService must not be null");
+        this.inqacccuService = Objects.requireNonNull(inqacccuService, "inqacccuService must not be null");
+        this.delcusRepository = Objects.requireNonNull(delcusRepository, "delcusRepository must not be null");
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+        this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    public DelcusResult delete(DelcusRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        return CrdbRetry.run(dsl, () -> transactionTemplate.execute(status -> deleteWithinTransaction(request)));
+    }
+
+    private DelcusResult deleteWithinTransaction(DelcusRequest request) {
+        InqcustResult customerResult = inqcustService.inquire(new InqcustRequest(request.customerNumber()));
+        if (!customerResult.inquirySuccess()) {
+            return DelcusResult.failure(customerResult.failCode(), customerResult.customerNumber(), customerResult.message());
+        }
+
+        CustomerDetails customer = Objects.requireNonNull(customerResult.customer(), "Successful inquiry requires a customer");
+        InqacccuResult accountsResult = inqacccuService.inquire(new InqacccuRequest(customer.customerNumber()));
+        List<AccountDetails> accounts = accountsToDelete(customer, accountsResult);
+
+        Instant now = Instant.now(clock);
+        long transactionReference = Math.max(0L, now.toEpochMilli());
+        LocalDate transactionDate = LocalDate.ofInstant(now, ZoneOffset.UTC);
+        LocalTime transactionTime = LocalTime.ofInstant(now, ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
+
+        for (AccountDetails account : accounts) {
+            deleteAccount(account, transactionReference, transactionDate, transactionTime);
+        }
+
+        deleteCustomer(customer, transactionReference, transactionDate, transactionTime);
+        return DelcusResult.success(customer);
+    }
+
+    private List<AccountDetails> accountsToDelete(CustomerDetails customer, InqacccuResult accountsResult) {
+        if (accountsResult.inquirySuccess()) {
+            return accountsResult.accounts();
+        }
+        if (accountsResult.isNotFoundFailure()) {
+            return List.of();
+        }
+
+        throw new CbsaAbendException(
+                ACCOUNT_INQUIRY_ABEND_CODE,
+                "DELCUS failed to read accounts for customer %d.".formatted(customer.customerNumber())
+        );
+    }
+
+    private void deleteAccount(AccountDetails account, long transactionReference, LocalDate transactionDate, LocalTime transactionTime) {
+        int deletedRows;
+        try {
+            deletedRows = delcusRepository.deleteAccount(account.sortcode(), account.accountNumber());
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(
+                    DELETE_ABEND_CODE,
+                    "DELCUS failed to delete account %d.".formatted(account.accountNumber()),
+                    exception
+            );
+        }
+
+        if (deletedRows == 0) {
+            return;
+        }
+        if (deletedRows != 1) {
+            throw new CbsaAbendException(
+                    DELETE_ABEND_CODE,
+                    "DELCUS deleted an unexpected number of rows for account %d.".formatted(account.accountNumber())
+            );
+        }
+
+        try {
+            delcusRepository.insertAccountDeletionAudit(account, transactionReference, transactionDate, transactionTime);
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
+                    "DELCUS failed to write the account deletion audit trail.",
+                    exception
+            );
+        }
+    }
+
+    private void deleteCustomer(CustomerDetails customer, long transactionReference, LocalDate transactionDate, LocalTime transactionTime) {
+        int deletedRows;
+        try {
+            deletedRows = delcusRepository.deleteCustomer(customer.sortcode(), customer.customerNumber());
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(DELETE_ABEND_CODE, "DELCUS failed to delete the customer data.", exception);
+        }
+
+        if (deletedRows == 0) {
+            return;
+        }
+        if (deletedRows != 1) {
+            throw new CbsaAbendException(
+                    DELETE_ABEND_CODE,
+                    "DELCUS deleted an unexpected number of rows for customer %d.".formatted(customer.customerNumber())
+            );
+        }
+
+        try {
+            delcusRepository.insertCustomerDeletionAudit(customer, transactionReference, transactionDate, transactionTime);
+        } catch (DataAccessException exception) {
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
+                    "DELCUS failed to write the customer deletion audit trail.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/DelcusService.java
+++ b/src/main/java/com/augment/cbsa/service/DelcusService.java
@@ -11,6 +11,7 @@ import com.augment.cbsa.domain.InqcustResult;
 import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.repository.CrdbRetry;
 import com.augment.cbsa.repository.DelcusRepository;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -102,6 +103,9 @@ public class DelcusService {
         try {
             deletedRows = delcusRepository.deleteAccount(account.sortcode(), account.accountNumber());
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(
                     DELETE_ABEND_CODE,
                     "DELCUS failed to delete account %d.".formatted(account.accountNumber()),
@@ -122,6 +126,9 @@ public class DelcusService {
         try {
             delcusRepository.insertAccountDeletionAudit(account, transactionReference, transactionDate, transactionTime);
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(
                     PROCTRAN_ABEND_CODE,
                     "DELCUS failed to write the account deletion audit trail.",
@@ -135,11 +142,20 @@ public class DelcusService {
         try {
             deletedRows = delcusRepository.deleteCustomer(customer.sortcode(), customer.customerNumber());
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(DELETE_ABEND_CODE, "DELCUS failed to delete the customer data.", exception);
         }
 
         if (deletedRows == 0) {
-            return;
+            // INQCUST already confirmed the customer exists within this transaction;
+            // a 0-row delete therefore indicates a concurrent removal and must abend
+            // rather than report success.
+            throw new CbsaAbendException(
+                    DELETE_ABEND_CODE,
+                    "DELCUS could not delete customer %d (concurrently removed).".formatted(customer.customerNumber())
+            );
         }
         if (deletedRows != 1) {
             throw new CbsaAbendException(
@@ -151,11 +167,25 @@ public class DelcusService {
         try {
             delcusRepository.insertCustomerDeletionAudit(customer, transactionReference, transactionDate, transactionTime);
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw new CbsaAbendException(
                     PROCTRAN_ABEND_CODE,
                     "DELCUS failed to write the customer deletion audit trail.",
                     exception
             );
         }
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
@@ -1,0 +1,110 @@
+package com.augment.cbsa.web.delcus;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.DelcusRequest;
+import com.augment.cbsa.domain.DelcusResult;
+import com.augment.cbsa.service.DelcusService;
+import com.augment.cbsa.web.delcus.dto.DelcusCommareaResponseDto;
+import com.augment.cbsa.web.delcus.dto.DelcusRequestDto;
+import com.augment.cbsa.web.delcus.dto.DelcusResponseDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/delcus")
+public class DelcusController {
+
+    private static final String EYE_CATCHER = "CUST";
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
+
+    private final DelcusService delcusService;
+
+    public DelcusController(DelcusService delcusService) {
+        this.delcusService = Objects.requireNonNull(delcusService, "delcusService must not be null");
+    }
+
+    @DeleteMapping("/remove/{customerNumber}")
+    public ResponseEntity<?> delete(
+            @PathVariable
+            @Pattern(regexp = "[0-9]{1,10}")
+            String customerNumber,
+            @Valid @RequestBody DelcusRequestDto requestDto
+    ) {
+        // The z/OS Connect contract carries the full commarea shape in the body,
+        // but DELCUS itself only consumes COMM-CUSTNO.
+        Objects.requireNonNull(requestDto, "requestDto must not be null");
+
+        DelcusResult result = delcusService.delete(new DelcusRequest(Long.parseLong(customerNumber)));
+        if (!result.deleteSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private HttpStatus failureStatus(DelcusResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(DelcusResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(DelcusResult result) {
+        if (result.isNotFoundFailure()) {
+            return "Customer not found";
+        }
+        if (result.isRandomRetryExhaustedFailure()) {
+            return "Customer deletion retry exhausted";
+        }
+        return "Customer deletion failed";
+    }
+
+    private DelcusResponseDto toResponse(DelcusResult result) {
+        CustomerDetails customer = Objects.requireNonNull(result.customer(), "Successful response requires a customer");
+        return new DelcusResponseDto(new DelcusCommareaResponseDto(
+                EYE_CATCHER,
+                customer.sortcode(),
+                String.format(Locale.ROOT, "%010d", customer.customerNumber()),
+                customer.name(),
+                customer.address(),
+                toCobolDate(customer.dateOfBirth()),
+                customer.creditScore(),
+                toCobolDate(customer.csReviewDate()),
+                "Y",
+                ""
+        ));
+    }
+
+    private int toCobolDate(LocalDate date) {
+        if (date == null) {
+            return 0;
+        }
+        return Integer.parseInt(date.format(COBOL_DATE_FORMATTER));
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
@@ -9,6 +9,7 @@ import com.augment.cbsa.web.delcus.dto.DelcusRequestDto;
 import com.augment.cbsa.web.delcus.dto.DelcusResponseDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -40,7 +41,8 @@ public class DelcusController {
     @DeleteMapping("/remove/{customerNumber}")
     public ResponseEntity<?> delete(
             @PathVariable
-            @Pattern(regexp = "[0-9]{1,10}")
+            @Size(max = 10)
+            @Pattern(regexp = "0*[1-9][0-9]*")
             String customerNumber,
             @Valid @RequestBody DelcusRequestDto requestDto
     ) {

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaRequestDto.java
@@ -1,0 +1,49 @@
+package com.augment.cbsa.web.delcus.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record DelcusCommareaRequestDto(
+        @JsonProperty("CommEye")
+        @Size(max = 4)
+        String commEye,
+
+        @JsonProperty("CommScode")
+        @Pattern(regexp = "[0-9]{0,6}")
+        String commScode,
+
+        @JsonProperty("CommName")
+        @Size(max = 60)
+        String commName,
+
+        @JsonProperty("CommAddr")
+        @Size(max = 160)
+        String commAddr,
+
+        @JsonProperty("CommDob")
+        @Min(0)
+        @Max(99_999_999)
+        Integer commDob,
+
+        @JsonProperty("CommCreditScore")
+        @Min(0)
+        @Max(999)
+        Integer commCreditScore,
+
+        @JsonProperty("CommCsReviewDate")
+        @Min(0)
+        @Max(99_999_999)
+        Integer commCsReviewDate,
+
+        @JsonProperty("CommDelSuccess")
+        @Size(max = 1)
+        String commDelSuccess,
+
+        @JsonProperty("CommDelFailCd")
+        @Size(max = 1)
+        String commDelFailCd
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaRequestDto.java
@@ -15,6 +15,10 @@ public record DelcusCommareaRequestDto(
         @Pattern(regexp = "[0-9]{0,6}")
         String commScode,
 
+        @JsonProperty("CommCustno")
+        @Pattern(regexp = "[0-9]{0,10}")
+        String commCustno,
+
         @JsonProperty("CommName")
         @Size(max = 60)
         String commName,

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusCommareaResponseDto.java
@@ -1,0 +1,36 @@
+package com.augment.cbsa.web.delcus.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DelcusCommareaResponseDto(
+        @JsonProperty("CommEye")
+        String commEye,
+
+        @JsonProperty("CommScode")
+        String commScode,
+
+        @JsonProperty("CommCustno")
+        String commCustno,
+
+        @JsonProperty("CommName")
+        String commName,
+
+        @JsonProperty("CommAddr")
+        String commAddr,
+
+        @JsonProperty("CommDob")
+        int commDob,
+
+        @JsonProperty("CommCreditScore")
+        int commCreditScore,
+
+        @JsonProperty("CommCsReviewDate")
+        int commCsReviewDate,
+
+        @JsonProperty("CommDelSuccess")
+        String commDelSuccess,
+
+        @JsonProperty("CommDelFailCd")
+        String commDelFailCd
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusRequestDto.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.web.delcus.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record DelcusRequestDto(
+        @JsonProperty("DelCus")
+        @Valid
+        @NotNull
+        DelcusCommareaRequestDto delCus
+) {
+
+    public DelcusRequestDto {
+        Objects.requireNonNull(delCus, "delCus must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusResponseDto.java
@@ -1,0 +1,14 @@
+package com.augment.cbsa.web.delcus.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public record DelcusResponseDto(
+        @JsonProperty("DelCus")
+        DelcusCommareaResponseDto delCus
+) {
+
+    public DelcusResponseDto {
+        Objects.requireNonNull(delCus, "delCus must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -3,9 +3,11 @@ package com.augment.cbsa;
 import com.augment.cbsa.repository.AccountRepository;
 import com.augment.cbsa.repository.CreaccRepository;
 import com.augment.cbsa.repository.CrecustRepository;
+import com.augment.cbsa.repository.DelcusRepository;
 import com.augment.cbsa.repository.CustomerRepository;
 import com.augment.cbsa.repository.UpdaccRepository;
 import com.augment.cbsa.repository.UpdcustRepository;
+import com.augment.cbsa.service.DelcusService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -43,6 +45,12 @@ class CbsaApplicationTests {
 
     @MockitoBean
     private UpdaccRepository updaccRepository;
+
+    @MockitoBean
+    private DelcusRepository delcusRepository;
+
+    @MockitoBean
+    private DelcusService delcusService;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/DelcusServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/DelcusServiceIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.DelcusRequest;
+import com.augment.cbsa.domain.DelcusResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.jooq.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DelcusServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private DelcusService delcusService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void deletesCustomerAccountsAndWritesAuditRows() {
+        insertCustomer(10L, "Mr Alice Example");
+        insertAccount(10L, 100L, "ISA", new BigDecimal("1499.75"));
+        insertAccount(10L, 200L, "SAVINGS", new BigDecimal("500.00"));
+
+        DelcusResult result = delcusService.delete(new DelcusRequest(10L));
+
+        assertThat(result.deleteSuccess()).isTrue();
+        assertThat(result.customer()).isNotNull();
+        assertThat(dsl.fetchCount(CUSTOMER)).isZero();
+        assertThat(dsl.fetchCount(ACCOUNT)).isZero();
+        assertThat(dsl.fetchCount(PROCTRAN)).isEqualTo(3);
+
+        Result<?> auditRows = dsl.select(PROCTRAN.TRAN_TYPE, PROCTRAN.DESCRIPTION, PROCTRAN.AMOUNT)
+                .from(PROCTRAN)
+                .orderBy(PROCTRAN.COUNTER.asc())
+                .fetch();
+
+        assertThat(auditRows.getValues(PROCTRAN.TRAN_TYPE)).containsExactly("ODA", "ODA", "ODC");
+        assertThat(auditRows.get(0).get(PROCTRAN.DESCRIPTION)).isEqualTo("0000000010ISA     0302202404032024DELETE");
+        assertThat(auditRows.get(1).get(PROCTRAN.DESCRIPTION)).isEqualTo("0000000010SAVINGS 0302202404032024DELETE");
+        assertThat(auditRows.get(2).get(PROCTRAN.DESCRIPTION)).startsWith("9876540000000010Mr Alice Examp10/01/2000");
+        assertThat(auditRows.get(0).get(PROCTRAN.AMOUNT)).isEqualTo(new BigDecimal("1499.75"));
+        assertThat(auditRows.get(2).get(PROCTRAN.AMOUNT)).isEqualTo(new BigDecimal("0.00"));
+    }
+
+    @Test
+    void returnsNotFoundWithoutWritingAuditRows() {
+        DelcusResult result = delcusService.delete(new DelcusRequest(10L));
+
+        assertThat(result.deleteSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+    }
+
+    private void insertCustomer(long customerNumber, String name) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, name)
+                .set(CUSTOMER.ADDRESS, "1 Main Street")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(2000, 1, 10))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 430)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2026, 5, 8))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, String accountType, BigDecimal actualBalance) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, accountType)
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, actualBalance)
+                .set(ACCOUNT.ACTUAL_BALANCE, actualBalance)
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/DelcusServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DelcusServiceUnitTest.java
@@ -1,0 +1,159 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.DelcusRequest;
+import com.augment.cbsa.domain.DelcusResult;
+import com.augment.cbsa.domain.InqacccuRequest;
+import com.augment.cbsa.domain.InqacccuResult;
+import com.augment.cbsa.domain.InqcustRequest;
+import com.augment.cbsa.domain.InqcustResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.DelcusRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DelcusServiceUnitTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-01T10:15:30Z"), ZoneOffset.UTC);
+
+    private InqcustService inqcustService;
+    private InqacccuService inqacccuService;
+    private DelcusRepository delcusRepository;
+    private DelcusService delcusService;
+
+    @BeforeEach
+    void setUp() {
+        inqcustService = mock(InqcustService.class);
+        inqacccuService = mock(InqacccuService.class);
+        delcusRepository = mock(DelcusRepository.class);
+        DSLContext dsl = mock(DSLContext.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            TransactionCallback<DelcusResult> callback = invocation.getArgument(0);
+            return callback.doInTransaction(new SimpleTransactionStatus());
+        });
+
+        delcusService = new DelcusService(
+                inqcustService,
+                inqacccuService,
+                delcusRepository,
+                dsl,
+                transactionTemplate,
+                FIXED_CLOCK
+        );
+    }
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        assertThatThrownBy(() -> delcusService.delete(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(inqcustService, inqacccuService, delcusRepository);
+    }
+
+    @Test
+    void returnsCustomerInquiryFailureWithoutTouchingDeletionFlow() {
+        when(inqcustService.inquire(new InqcustRequest(1L)))
+                .thenReturn(InqcustResult.failure("1", 1L, "Customer number 1 was not found."));
+
+        DelcusResult result = delcusService.delete(new DelcusRequest(1L));
+
+        assertThat(result.deleteSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        verifyNoInteractions(inqacccuService, delcusRepository);
+    }
+
+    @Test
+    void deletesResolvedCustomerAndSkipsAccountAuditWhenTheRowIsAlreadyGone() {
+        CustomerDetails customer = customer(42L);
+        AccountDetails firstAccount = account(42L, 100L, "ISA", new BigDecimal("1499.75"));
+        AccountDetails secondAccount = account(42L, 200L, "SAVINGS", new BigDecimal("500.00"));
+
+        when(inqcustService.inquire(new InqcustRequest(0L))).thenReturn(InqcustResult.success(customer));
+        when(inqacccuService.inquire(new InqacccuRequest(42L))).thenReturn(InqacccuResult.success(42L, java.util.List.of(firstAccount, secondAccount)));
+        when(delcusRepository.deleteAccount("987654", 100L)).thenReturn(1);
+        when(delcusRepository.deleteAccount("987654", 200L)).thenReturn(0);
+        when(delcusRepository.deleteCustomer("987654", 42L)).thenReturn(1);
+
+        DelcusResult result = delcusService.delete(new DelcusRequest(0L));
+
+        assertThat(result.deleteSuccess()).isTrue();
+        assertThat(result.customer()).isEqualTo(customer);
+        verify(inqacccuService).inquire(new InqacccuRequest(42L));
+        verify(delcusRepository).insertAccountDeletionAudit(
+                eq(firstAccount),
+                eq(1_777_630_530_000L),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30))
+        );
+        verify(delcusRepository).insertCustomerDeletionAudit(
+                eq(customer),
+                eq(1_777_630_530_000L),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30))
+        );
+    }
+
+    @Test
+    void abendsWhenAccountInquiryFailsAfterCustomerLookup() {
+        CustomerDetails customer = customer(42L);
+        when(inqcustService.inquire(new InqcustRequest(42L))).thenReturn(InqcustResult.success(customer));
+        when(inqacccuService.inquire(new InqacccuRequest(42L)))
+                .thenReturn(InqacccuResult.failure("3", 42L, true, "INQACCCU failed while fetching account data."));
+
+        assertThatThrownBy(() -> delcusService.delete(new DelcusRequest(42L)))
+                .isInstanceOf(CbsaAbendException.class)
+                .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
+                .isEqualTo("WPV6");
+        verifyNoInteractions(delcusRepository);
+    }
+
+    private CustomerDetails customer(long customerNumber) {
+        return new CustomerDetails(
+                "987654",
+                customerNumber,
+                "Mr Alice Example",
+                "1 Main Street",
+                LocalDate.of(2000, 1, 10),
+                430,
+                LocalDate.of(2026, 5, 8)
+        );
+    }
+
+    private AccountDetails account(long customerNumber, long accountNumber, String accountType, BigDecimal actualBalance) {
+        return new AccountDetails(
+                "987654",
+                customerNumber,
+                accountNumber,
+                accountType,
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                actualBalance,
+                actualBalance
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/DelcusServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DelcusServiceUnitTest.java
@@ -85,18 +85,27 @@ class DelcusServiceUnitTest {
     }
 
     @Test
+    void rejectsZeroCustomerNumberWithoutInvokingTheRandomCustomerPath() {
+        DelcusResult result = delcusService.delete(new DelcusRequest(0L));
+
+        assertThat(result.deleteSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        verifyNoInteractions(inqcustService, inqacccuService, delcusRepository);
+    }
+
+    @Test
     void deletesResolvedCustomerAndSkipsAccountAuditWhenTheRowIsAlreadyGone() {
         CustomerDetails customer = customer(42L);
         AccountDetails firstAccount = account(42L, 100L, "ISA", new BigDecimal("1499.75"));
         AccountDetails secondAccount = account(42L, 200L, "SAVINGS", new BigDecimal("500.00"));
 
-        when(inqcustService.inquire(new InqcustRequest(0L))).thenReturn(InqcustResult.success(customer));
+        when(inqcustService.inquire(new InqcustRequest(42L))).thenReturn(InqcustResult.success(customer));
         when(inqacccuService.inquire(new InqacccuRequest(42L))).thenReturn(InqacccuResult.success(42L, java.util.List.of(firstAccount, secondAccount)));
         when(delcusRepository.deleteAccount("987654", 100L)).thenReturn(1);
         when(delcusRepository.deleteAccount("987654", 200L)).thenReturn(0);
         when(delcusRepository.deleteCustomer("987654", 42L)).thenReturn(1);
 
-        DelcusResult result = delcusService.delete(new DelcusRequest(0L));
+        DelcusResult result = delcusService.delete(new DelcusRequest(42L));
 
         assertThat(result.deleteSuccess()).isTrue();
         assertThat(result.customer()).isEqualTo(customer);

--- a/src/test/java/com/augment/cbsa/web/delcus/DelcusControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/delcus/DelcusControllerWebMvcTest.java
@@ -1,0 +1,103 @@
+package com.augment.cbsa.web.delcus;
+
+import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.domain.DelcusRequest;
+import com.augment.cbsa.domain.DelcusResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.DelcusService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DelcusController.class)
+@Import(CbsaExceptionHandler.class)
+class DelcusControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DelcusService delcusService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(delcusService.delete(new DelcusRequest(1L))).thenReturn(DelcusResult.success(new CustomerDetails(
+                "987654",
+                1L,
+                "Mr Alice Example",
+                "1 Main Street",
+                LocalDate.of(2000, 1, 10),
+                430,
+                LocalDate.of(2026, 5, 8)
+        )));
+
+        mockMvc.perform(delete("/api/v1/delcus/remove/1").contentType(APPLICATION_JSON).content(requestJson()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.DelCus.CommEye").value("CUST"))
+                .andExpect(jsonPath("$.DelCus.CommScode").value("987654"))
+                .andExpect(jsonPath("$.DelCus.CommCustno").value("0000000001"))
+                .andExpect(jsonPath("$.DelCus.CommDelSuccess").value("Y"));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(delcusService.delete(new DelcusRequest(1L)))
+                .thenReturn(DelcusResult.failure("1", 1L, "Customer number 1 was not found."));
+
+        mockMvc.perform(delete("/api/v1/delcus/remove/1").contentType(APPLICATION_JSON).content(requestJson()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Customer not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(delete("/api/v1/delcus/remove/abc").contentType(APPLICATION_JSON).content(requestJson()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void redactsAbendExceptionMessageFromResponseBody() throws Exception {
+        when(delcusService.delete(new DelcusRequest(1L)))
+                .thenThrow(new CbsaAbendException("WPV7", "sensitive delete details"));
+
+        mockMvc.perform(delete("/api/v1/delcus/remove/1").contentType(APPLICATION_JSON).content(requestJson()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Service abend"))
+                .andExpect(jsonPath("$.abendCode").value("WPV7"))
+                .andExpect(content().string(not(containsString("sensitive delete details"))));
+    }
+
+    private String requestJson() {
+        return """
+                {
+                  "DelCus": {
+                    "CommEye": "CUST",
+                    "CommScode": "987654",
+                    "CommName": "",
+                    "CommAddr": "",
+                    "CommDob": 0,
+                    "CommCreditScore": 0,
+                    "CommCsReviewDate": 0,
+                    "CommDelSuccess": " ",
+                    "CommDelFailCd": " "
+                  }
+                }
+                """;
+    }
+}


### PR DESCRIPTION
**Source program**: https://github.com/cicsdev/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/DELCUS.cbl

**Mapped REST endpoints**
- DELETE /api/v1/delcus/remove/{customerNumber}

**Notable decisions**
- Modelled DELCUS as a transactional delete flow that removes the customer and all associated accounts atomically.
- Wrote PROCTRAN audit rows for deleted accounts using the COBOL-style description layout, including 8-character space padding for account type.
- Preserved the z/OS Connect commarea wrapper contract in request/response DTOs even though the business operation only consumes the customer number.
- Returned typed failure responses for not-found and retry-exhausted cases while letting existing CBSA abend handling redact sensitive internal errors.
- Reused existing customer/account domain types instead of introducing copybook-style duplication.

**Test coverage**
- unit
- @SpringBootTest
- MockMvc
