### PR TITLE
migrate(DBCRFUN): translate payment debit/credit flow

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/DbcrfunOrigin.java
+++ b/src/main/java/com/augment/cbsa/domain/DbcrfunOrigin.java
@@ -1,0 +1,37 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+
+public record DbcrfunOrigin(
+        String applid,
+        String userid,
+        String facilityName,
+        String netwrkId,
+        int facilityType,
+        String fill0
+) {
+
+    public DbcrfunOrigin {
+        Objects.requireNonNull(applid, "applid must not be null");
+        Objects.requireNonNull(userid, "userid must not be null");
+        Objects.requireNonNull(facilityName, "facilityName must not be null");
+        Objects.requireNonNull(netwrkId, "netwrkId must not be null");
+        Objects.requireNonNull(fill0, "fill0 must not be null");
+    }
+
+    public static DbcrfunOrigin blank() {
+        return new DbcrfunOrigin("", "", "", "", 0, "");
+    }
+
+    public String paymentDescription() {
+        String header = padRight(applid, 8) + padRight(userid, 8);
+        return header.substring(0, 14);
+    }
+
+    private static String padRight(String value, int length) {
+        if (value.length() >= length) {
+            return value.substring(0, length);
+        }
+        return value + " ".repeat(length - value.length());
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/DbcrfunRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/DbcrfunRequest.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+public record DbcrfunRequest(
+        long accountNumber,
+        BigDecimal amount,
+        DbcrfunOrigin origin
+) {
+
+    public DbcrfunRequest {
+        Objects.requireNonNull(amount, "amount must not be null");
+        Objects.requireNonNull(origin, "origin must not be null");
+        amount = amount.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/DbcrfunResult.java
+++ b/src/main/java/com/augment/cbsa/domain/DbcrfunResult.java
@@ -1,0 +1,56 @@
+package com.augment.cbsa.domain;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record DbcrfunResult(
+        boolean paymentSuccess,
+        String failCode,
+        AccountDetails account,
+        String message
+) {
+
+    private static final Set<String> NOT_FOUND_FAIL_CODES = Set.of("1");
+    private static final Set<String> CONFLICT_FAIL_CODES = Set.of("3", "4");
+
+    public DbcrfunResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (paymentSuccess && account == null) {
+            throw new IllegalArgumentException("Successful results must include an account");
+        }
+        if (!paymentSuccess && account != null) {
+            throw new IllegalArgumentException("Failure results must not include an account");
+        }
+        if (!paymentSuccess && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("Failure results must include a non-blank message");
+        }
+    }
+
+    public static DbcrfunResult success(AccountDetails account) {
+        Objects.requireNonNull(account, "account must not be null");
+        return new DbcrfunResult(true, "0", account, null);
+    }
+
+    public static DbcrfunResult failure(String failCode, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new DbcrfunResult(false, failCode, null, message);
+    }
+
+    public boolean isNotFoundFailure() {
+        return !paymentSuccess && NOT_FOUND_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isConflictFailure() {
+        return !paymentSuccess && CONFLICT_FAIL_CODES.contains(failCode);
+    }
+
+    public boolean isInsufficientFundsFailure() {
+        return !paymentSuccess && "3".equals(failCode);
+    }
+
+    public boolean isDisallowedAccountTypeFailure() {
+        return !paymentSuccess && "4".equals(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/DbcrfunRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/DbcrfunRepository.java
@@ -1,0 +1,78 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.jooq.tables.records.AccountRecord;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+
+@Repository
+public class DbcrfunRepository {
+
+    private final DSLContext dsl;
+
+    public DbcrfunRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public Optional<AccountDetails> lockAccount(String sortcode, long accountNumber) {
+        return dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .forUpdate()
+                .fetchOptional(this::toDomain);
+    }
+
+    public int updateBalances(String sortcode, long accountNumber, BigDecimal availableBalance, BigDecimal actualBalance) {
+        return dsl.update(ACCOUNT)
+                .set(ACCOUNT.AVAILABLE_BALANCE, availableBalance)
+                .set(ACCOUNT.ACTUAL_BALANCE, actualBalance)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .execute();
+    }
+
+    public void insertProcTran(
+            String sortcode,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime,
+            String transactionType,
+            String description,
+            BigDecimal amount
+    ) {
+        dsl.insertInto(PROCTRAN)
+                .set(PROCTRAN.SORTCODE, sortcode)
+                .set(PROCTRAN.LOGICAL_DELETE, false)
+                .set(PROCTRAN.TRAN_DATE, transactionDate)
+                .set(PROCTRAN.TRAN_TIME, transactionTime)
+                .set(PROCTRAN.TRAN_REF, transactionReference)
+                .set(PROCTRAN.TRAN_TYPE, transactionType)
+                .set(PROCTRAN.DESCRIPTION, description)
+                .set(PROCTRAN.AMOUNT, amount)
+                .execute();
+    }
+
+    private AccountDetails toDomain(AccountRecord record) {
+        return new AccountDetails(
+                record.getSortcode(),
+                record.getCustomerNumber(),
+                record.getAccountNumber(),
+                record.getAccountType(),
+                record.getInterestRate(),
+                record.getOpened(),
+                record.getOverdraftLimit(),
+                record.getLastStmtDate(),
+                record.getNextStmtDate(),
+                record.getAvailableBalance(),
+                record.getActualBalance()
+        );
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/DbcrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/DbcrfunService.java
@@ -1,0 +1,152 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.DbcrfunOrigin;
+import com.augment.cbsa.domain.DbcrfunRequest;
+import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.repository.CrdbRetry;
+import com.augment.cbsa.repository.DbcrfunRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class DbcrfunService {
+
+    static final int PAYMENT_FACILITY_TYPE = 496;
+
+    private final DbcrfunRepository dbcrfunRepository;
+    private final DSLContext dsl;
+    private final TransactionTemplate transactionTemplate;
+    private final String sortcode;
+    private final Clock clock;
+
+    public DbcrfunService(
+            DbcrfunRepository dbcrfunRepository,
+            DSLContext dsl,
+            TransactionTemplate transactionTemplate,
+            @Value("${cbsa.sortcode}") String sortcode,
+            Clock clock
+    ) {
+        this.dbcrfunRepository = Objects.requireNonNull(dbcrfunRepository, "dbcrfunRepository must not be null");
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+        this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    public DbcrfunResult process(DbcrfunRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        Instant now = Instant.now(clock);
+        try {
+            DbcrfunResult result = CrdbRetry.run(
+                    dsl,
+                    () -> transactionTemplate.execute(status -> processWithinTransaction(request, now))
+            );
+            return Objects.requireNonNull(result, "transactionTemplate returned null result");
+        } catch (DataAccessException exception) {
+            return DbcrfunResult.failure("2", "DBCRFUN failed to update the account data.");
+        }
+    }
+
+    private DbcrfunResult processWithinTransaction(DbcrfunRequest request, Instant now) {
+        Optional<AccountDetails> found = dbcrfunRepository.lockAccount(sortcode, request.accountNumber());
+        if (found.isEmpty()) {
+            return DbcrfunResult.failure("1", "Account number %d was not found.".formatted(request.accountNumber()));
+        }
+
+        AccountDetails account = found.get();
+        if (isPaymentFacility(request.origin()) && isRestrictedAccountType(account.accountType())) {
+            return DbcrfunResult.failure(
+                    "4",
+                    "Payments are not supported for account type %s.".formatted(account.accountType().trim())
+            );
+        }
+
+        BigDecimal updatedAvailableBalance = scale(account.availableBalance().add(request.amount()));
+        if (request.amount().signum() < 0
+                && isPaymentFacility(request.origin())
+                && updatedAvailableBalance.compareTo(BigDecimal.ZERO) < 0) {
+            return DbcrfunResult.failure(
+                    "3",
+                    "Account number %d does not have sufficient available funds.".formatted(request.accountNumber())
+            );
+        }
+
+        BigDecimal updatedActualBalance = scale(account.actualBalance().add(request.amount()));
+        int updatedRows = dbcrfunRepository.updateBalances(
+                sortcode,
+                request.accountNumber(),
+                updatedAvailableBalance,
+                updatedActualBalance
+        );
+        if (updatedRows != 1) {
+            return DbcrfunResult.failure("2", "DBCRFUN failed to update the account record.");
+        }
+
+        dbcrfunRepository.insertProcTran(
+                sortcode,
+                Math.max(0L, now.toEpochMilli()),
+                LocalDate.ofInstant(now, ZoneOffset.UTC),
+                LocalTime.ofInstant(now, ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS),
+                transactionType(request),
+                description(request),
+                request.amount()
+        );
+
+        return DbcrfunResult.success(new AccountDetails(
+                account.sortcode(),
+                account.customerNumber(),
+                account.accountNumber(),
+                account.accountType(),
+                account.interestRate(),
+                account.opened(),
+                account.overdraftLimit(),
+                account.lastStatementDate(),
+                account.nextStatementDate(),
+                updatedAvailableBalance,
+                updatedActualBalance
+        ));
+    }
+
+    private String transactionType(DbcrfunRequest request) {
+        boolean debit = request.amount().signum() < 0;
+        if (debit) {
+            return isPaymentFacility(request.origin()) ? "PDR" : "DEB";
+        }
+        return isPaymentFacility(request.origin()) ? "PCR" : "CRE";
+    }
+
+    private String description(DbcrfunRequest request) {
+        if (isPaymentFacility(request.origin())) {
+            return request.origin().paymentDescription();
+        }
+        return request.amount().signum() < 0 ? "COUNTER WTHDRW" : "COUNTER RECVED";
+    }
+
+    private boolean isPaymentFacility(DbcrfunOrigin origin) {
+        return origin.facilityType() == PAYMENT_FACILITY_TYPE;
+    }
+
+    private boolean isRestrictedAccountType(String accountType) {
+        String trimmed = accountType == null ? "" : accountType.trim();
+        return "MORTGAGE".equals(trimmed) || "LOAN".equals(trimmed);
+    }
+
+    private BigDecimal scale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
@@ -16,14 +16,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Validated
-@RequestMapping("/api/v1/makepayment")
+@RequestMapping("/api/v1/dbcrfun")
 public class DbcrfunController {
 
     private final DbcrfunService dbcrfunService;
@@ -32,8 +32,8 @@ public class DbcrfunController {
         this.dbcrfunService = Objects.requireNonNull(dbcrfunService, "dbcrfunService must not be null");
     }
 
-    @PutMapping("/dbcr")
-    public ResponseEntity<?> putPayment(@Valid @RequestBody DbcrfunRequestDto requestDto) {
+    @PostMapping
+    public ResponseEntity<?> postPayment(@Valid @RequestBody DbcrfunRequestDto requestDto) {
         DbcrfunCommareaRequestDto commarea = requestDto.paydbcr();
         DbcrfunRequest request = new DbcrfunRequest(
                 Long.parseLong(commarea.commAccno()),

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
@@ -1,0 +1,126 @@
+package com.augment.cbsa.web.dbcrfun;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.DbcrfunOrigin;
+import com.augment.cbsa.domain.DbcrfunRequest;
+import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.service.DbcrfunService;
+import com.augment.cbsa.web.dbcrfun.dto.DbcrfunCommareaRequestDto;
+import com.augment.cbsa.web.dbcrfun.dto.DbcrfunCommareaResponseDto;
+import com.augment.cbsa.web.dbcrfun.dto.DbcrfunOriginDto;
+import com.augment.cbsa.web.dbcrfun.dto.DbcrfunRequestDto;
+import com.augment.cbsa.web.dbcrfun.dto.DbcrfunResponseDto;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/makepayment")
+public class DbcrfunController {
+
+    private final DbcrfunService dbcrfunService;
+
+    public DbcrfunController(DbcrfunService dbcrfunService) {
+        this.dbcrfunService = Objects.requireNonNull(dbcrfunService, "dbcrfunService must not be null");
+    }
+
+    @PutMapping("/dbcr")
+    public ResponseEntity<?> putPayment(@Valid @RequestBody DbcrfunRequestDto requestDto) {
+        DbcrfunCommareaRequestDto commarea = requestDto.paydbcr();
+        DbcrfunRequest request = new DbcrfunRequest(
+                Long.parseLong(commarea.commAccno()),
+                commarea.commAmt(),
+                toOrigin(commarea.commOrigin())
+        );
+        DbcrfunResult result = dbcrfunService.process(request);
+
+        if (!result.paymentSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(toResponse(commarea, request, result));
+    }
+
+    private HttpStatus failureStatus(DbcrfunResult result) {
+        if (result.isNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isConflictFailure()) {
+            return HttpStatus.CONFLICT;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(DbcrfunResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(DbcrfunResult result) {
+        if (result.isNotFoundFailure()) {
+            return "Account not found";
+        }
+        if (result.isInsufficientFundsFailure()) {
+            return "Insufficient funds";
+        }
+        if (result.isDisallowedAccountTypeFailure()) {
+            return "Payment not permitted";
+        }
+        return "Payment failed";
+    }
+
+    private DbcrfunResponseDto toResponse(DbcrfunCommareaRequestDto commarea, DbcrfunRequest request, DbcrfunResult result) {
+        AccountDetails account = Objects.requireNonNull(result.account(), "Successful response requires an account");
+        return new DbcrfunResponseDto(new DbcrfunCommareaResponseDto(
+                commarea.commAccno(),
+                request.amount(),
+                Integer.parseInt(account.sortcode()),
+                account.availableBalance(),
+                account.actualBalance(),
+                toDto(request.origin()),
+                "Y",
+                "0"
+        ));
+    }
+
+    private DbcrfunOrigin toOrigin(DbcrfunOriginDto originDto) {
+        if (originDto == null) {
+            return DbcrfunOrigin.blank();
+        }
+        return new DbcrfunOrigin(
+                defaultString(originDto.commApplid()),
+                defaultString(originDto.commUserid()),
+                defaultString(originDto.commFacilityName()),
+                defaultString(originDto.commNetwrkId()),
+                originDto.commFaciltype() == null ? 0 : originDto.commFaciltype(),
+                defaultString(originDto.fill0())
+        );
+    }
+
+    private DbcrfunOriginDto toDto(DbcrfunOrigin origin) {
+        return new DbcrfunOriginDto(
+                origin.applid(),
+                origin.userid(),
+                origin.facilityName(),
+                origin.netwrkId(),
+                origin.facilityType(),
+                origin.fill0()
+        );
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
@@ -1,0 +1,57 @@
+package com.augment.cbsa.web.dbcrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public record DbcrfunCommareaRequestDto(
+        @JsonProperty("CommAccno")
+        @NotNull
+        @Pattern(regexp = "[0-9]{1,8}")
+        String commAccno,
+
+        @JsonProperty("CommAmt")
+        @NotNull
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commAmt,
+
+        @JsonProperty("mSortC")
+        @Min(0)
+        @Max(999_999)
+        Integer mSortC,
+
+        @JsonProperty("CommAvBal")
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commAvBal,
+
+        @JsonProperty("CommActBal")
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commActBal,
+
+        @JsonProperty("CommOrigin")
+        @Valid
+        DbcrfunOriginDto commOrigin,
+
+        @JsonProperty("CommSuccess")
+        @Size(max = 1)
+        String commSuccess,
+
+        @JsonProperty("CommFailCode")
+        @Size(max = 1)
+        String commFailCode
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
@@ -44,6 +44,7 @@ public record DbcrfunCommareaRequestDto(
 
         @JsonProperty("CommOrigin")
         @Valid
+        @NotNull
         DbcrfunOriginDto commOrigin,
 
         @JsonProperty("CommSuccess")

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaResponseDto.java
@@ -1,0 +1,31 @@
+package com.augment.cbsa.web.dbcrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public record DbcrfunCommareaResponseDto(
+        @JsonProperty("CommAccno")
+        String commAccno,
+
+        @JsonProperty("CommAmt")
+        BigDecimal commAmt,
+
+        @JsonProperty("mSortC")
+        int mSortC,
+
+        @JsonProperty("CommAvBal")
+        BigDecimal commAvBal,
+
+        @JsonProperty("CommActBal")
+        BigDecimal commActBal,
+
+        @JsonProperty("CommOrigin")
+        DbcrfunOriginDto commOrigin,
+
+        @JsonProperty("CommSuccess")
+        String commSuccess,
+
+        @JsonProperty("CommFailCode")
+        String commFailCode
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunOriginDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunOriginDto.java
@@ -1,0 +1,34 @@
+package com.augment.cbsa.web.dbcrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record DbcrfunOriginDto(
+        @JsonProperty("CommApplid")
+        @Size(max = 8)
+        String commApplid,
+
+        @JsonProperty("CommUserid")
+        @Size(max = 8)
+        String commUserid,
+
+        @JsonProperty("CommFacilityName")
+        @Size(max = 8)
+        String commFacilityName,
+
+        @JsonProperty("CommNetwrkId")
+        @Size(max = 8)
+        String commNetwrkId,
+
+        @JsonProperty("CommFaciltype")
+        @Min(-99_999_999)
+        @Max(99_999_999)
+        Integer commFaciltype,
+
+        @JsonProperty("Fill0")
+        @Size(max = 4)
+        String fill0
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunOriginDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunOriginDto.java
@@ -3,6 +3,7 @@ package com.augment.cbsa.web.dbcrfun.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record DbcrfunOriginDto(
@@ -23,6 +24,7 @@ public record DbcrfunOriginDto(
         String commNetwrkId,
 
         @JsonProperty("CommFaciltype")
+        @NotNull
         @Min(-99_999_999)
         @Max(99_999_999)
         Integer commFaciltype,

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunRequestDto.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.web.dbcrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record DbcrfunRequestDto(
+        @JsonProperty("PAYDBCR")
+        @Valid
+        @NotNull
+        DbcrfunCommareaRequestDto paydbcr
+) {
+
+    public DbcrfunRequestDto {
+        Objects.requireNonNull(paydbcr, "paydbcr must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunResponseDto.java
@@ -1,0 +1,14 @@
+package com.augment.cbsa.web.dbcrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public record DbcrfunResponseDto(
+        @JsonProperty("PAYDBCR")
+        DbcrfunCommareaResponseDto paydbcr
+) {
+
+    public DbcrfunResponseDto {
+        Objects.requireNonNull(paydbcr, "paydbcr must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -3,10 +3,12 @@ package com.augment.cbsa;
 import com.augment.cbsa.repository.AccountRepository;
 import com.augment.cbsa.repository.CreaccRepository;
 import com.augment.cbsa.repository.CrecustRepository;
+import com.augment.cbsa.repository.DbcrfunRepository;
 import com.augment.cbsa.repository.DelcusRepository;
 import com.augment.cbsa.repository.CustomerRepository;
 import com.augment.cbsa.repository.UpdaccRepository;
 import com.augment.cbsa.repository.UpdcustRepository;
+import com.augment.cbsa.service.DbcrfunService;
 import com.augment.cbsa.service.DelcusService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,7 +52,13 @@ class CbsaApplicationTests {
     private DelcusRepository delcusRepository;
 
     @MockitoBean
+    private DbcrfunRepository dbcrfunRepository;
+
+    @MockitoBean
     private DelcusService delcusService;
+
+    @MockitoBean
+    private DbcrfunService dbcrfunService;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
@@ -1,0 +1,167 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.DbcrfunOrigin;
+import com.augment.cbsa.domain.DbcrfunRequest;
+import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.repository.DbcrfunRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DbcrfunServiceUnitTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-01T10:15:30Z"), ZoneOffset.UTC);
+
+    private DbcrfunRepository dbcrfunRepository;
+    private DbcrfunService dbcrfunService;
+
+    @BeforeEach
+    void setUp() {
+        dbcrfunRepository = mock(DbcrfunRepository.class);
+        DSLContext dsl = mock(DSLContext.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            TransactionCallback<DbcrfunResult> callback = invocation.getArgument(0, TransactionCallback.class);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
+        dbcrfunService = new DbcrfunService(dbcrfunRepository, dsl, transactionTemplate, "987654", FIXED_CLOCK);
+    }
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        assertThatThrownBy(() -> dbcrfunService.process(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(dbcrfunRepository);
+    }
+
+    @Test
+    void returnsNotFoundWhenAccountDoesNotExist() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenReturn(Optional.empty());
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("25.00"), 496));
+
+        assertThat(result.paymentSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("Account number 12345678 was not found.");
+    }
+
+    @Test
+    void rejectsPaymentFacilityRequestsForMortgageAccounts() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenReturn(Optional.of(account("MORTGAGE", "500.00")));
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("25.00"), 496));
+
+        assertThat(result.paymentSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("4");
+        assertThat(result.message()).isEqualTo("Payments are not supported for account type MORTGAGE.");
+    }
+
+    @Test
+    void rejectsPaymentDebitsThatWouldOverdrawAvailableFunds() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenReturn(Optional.of(account("ISA", "10.00")));
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("-25.00"), 496));
+
+        assertThat(result.paymentSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("3");
+        assertThat(result.message()).isEqualTo("Account number 12345678 does not have sufficient available funds.");
+    }
+
+    @Test
+    void writesPaymentCreditAuditRowsUsingTheOriginHeader() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenReturn(Optional.of(account("ISA", "100.00")));
+        when(dbcrfunRepository.updateBalances("987654", 12345678L, new BigDecimal("125.00"), new BigDecimal("125.00")))
+                .thenReturn(1);
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("25.00"), 496));
+
+        assertThat(result.paymentSuccess()).isTrue();
+        assertThat(result.account().availableBalance()).isEqualByComparingTo("125.00");
+        verify(dbcrfunRepository).insertProcTran(
+                eq("987654"),
+                anyLong(),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30)),
+                eq("PCR"),
+                eq("ABCDEFGH123456"),
+                eq(new BigDecimal("25.00"))
+        );
+    }
+
+    @Test
+    void allowsTellerDebitsToOverdrawAndWritesCounterWithdrawalAudit() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenReturn(Optional.of(account("ISA", "10.00")));
+        when(dbcrfunRepository.updateBalances("987654", 12345678L, new BigDecimal("-15.00"), new BigDecimal("-15.00")))
+                .thenReturn(1);
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("-25.00"), 0));
+
+        assertThat(result.paymentSuccess()).isTrue();
+        assertThat(result.account().availableBalance()).isEqualByComparingTo("-15.00");
+        verify(dbcrfunRepository).insertProcTran(
+                eq("987654"),
+                anyLong(),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30)),
+                eq("DEB"),
+                eq("COUNTER WTHDRW"),
+                eq(new BigDecimal("-25.00"))
+        );
+    }
+
+    @Test
+    void returnsGenericFailureWhenPersistenceThrowsDataAccessException() {
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenThrow(new DataAccessException("boom") {
+        });
+
+        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("25.00"), 496));
+
+        assertThat(result.paymentSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(result.message()).isEqualTo("DBCRFUN failed to update the account data.");
+    }
+
+    private DbcrfunRequest request(BigDecimal amount, int facilityType) {
+        return new DbcrfunRequest(12345678L, amount, new DbcrfunOrigin("ABCDEFGH", "12345678", "PAYAPI", "NET00001", facilityType, ""));
+    }
+
+    private AccountDetails account(String accountType, String balance) {
+        return new AccountDetails(
+                "987654",
+                10L,
+                12345678L,
+                accountType,
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal(balance),
+                new BigDecimal(balance)
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
@@ -18,7 +18,7 @@ import static com.augment.cbsa.jooq.Tables.CUSTOMER;
 import static com.augment.cbsa.jooq.Tables.PROCTRAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,7 +47,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
         insertCustomer(10L);
         insertAccount(10L, new BigDecimal("500.00"));
 
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
                 .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
@@ -83,7 +83,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
         insertCustomer(10L);
         insertAccount(10L, new BigDecimal("10.00"));
 
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.title").value("Insufficient funds"))
                 .andExpect(jsonPath("$.failCode").value("3"));

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
@@ -47,6 +47,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
         insertCustomer(10L);
         insertAccount(10L, new BigDecimal("500.00"));
 
+        LocalDate beforeRequest = LocalDate.now(clock);
         mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
@@ -75,7 +76,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
         assertThat(auditRow.value1()).isEqualTo("PDR");
         assertThat(auditRow.value2()).isEqualTo("ABCDEFGH123456");
         assertThat(auditRow.value3()).isEqualTo(new BigDecimal("-25.00"));
-        assertThat(auditRow.value4()).isEqualTo(LocalDate.now(clock));
+        assertThat(auditRow.value4()).isIn(beforeRequest, beforeRequest.plusDays(1));
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
@@ -1,0 +1,151 @@
+package com.augment.cbsa.web.dbcrfun;
+
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.jooq.Record4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private Clock clock;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void updatesBalancesAndWritesPaymentAuditRows() throws Exception {
+        insertCustomer(10L);
+        insertAccount(10L, new BigDecimal("500.00"));
+
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
+                .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
+                .andExpect(jsonPath("$.PAYDBCR.CommAvBal").value(475.00))
+                .andExpect(jsonPath("$.PAYDBCR.CommActBal").value(475.00))
+                .andExpect(jsonPath("$.PAYDBCR.CommSuccess").value("Y"))
+                .andExpect(jsonPath("$.PAYDBCR.CommFailCode").value("0"));
+
+        assertThat(dsl.select(ACCOUNT.AVAILABLE_BALANCE, ACCOUNT.ACTUAL_BALANCE)
+                .from(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchSingle())
+                .extracting(record -> record.get(ACCOUNT.AVAILABLE_BALANCE), record -> record.get(ACCOUNT.ACTUAL_BALANCE))
+                .containsExactly(new BigDecimal("475.00"), new BigDecimal("475.00"));
+
+        Record4<String, String, BigDecimal, LocalDate> auditRow = dsl.select(
+                        PROCTRAN.TRAN_TYPE,
+                        PROCTRAN.DESCRIPTION,
+                        PROCTRAN.AMOUNT,
+                        PROCTRAN.TRAN_DATE
+                )
+                .from(PROCTRAN)
+                .fetchSingle();
+        assertThat(auditRow.value1()).isEqualTo("PDR");
+        assertThat(auditRow.value2()).isEqualTo("ABCDEFGH123456");
+        assertThat(auditRow.value3()).isEqualTo(new BigDecimal("-25.00"));
+        assertThat(auditRow.value4()).isEqualTo(LocalDate.now(clock));
+    }
+
+    @Test
+    void returnsConflictWhenPaymentWouldOverdrawAccount() throws Exception {
+        insertCustomer(10L);
+        insertAccount(10L, new BigDecimal("10.00"));
+
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("Insufficient funds"))
+                .andExpect(jsonPath("$.failCode").value("3"));
+
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+        assertThat(dsl.select(ACCOUNT.AVAILABLE_BALANCE)
+                .from(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchSingle(ACCOUNT.AVAILABLE_BALANCE))
+                .isEqualTo(new BigDecimal("10.00"));
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer")
+                .set(CUSTOMER.ADDRESS, "1 Example Road")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, BigDecimal balance) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, 12345678L)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, "ISA")
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, balance)
+                .set(ACCOUNT.ACTUAL_BALANCE, balance)
+                .execute();
+    }
+
+    private String requestJson(String amount, int facilityType) {
+        return """
+                {
+                  "PAYDBCR": {
+                    "CommAccno": "12345678",
+                    "CommAmt": %s,
+                    "mSortC": 0,
+                    "CommAvBal": 0,
+                    "CommActBal": 0,
+                    "CommOrigin": {
+                      "CommApplid": "ABCDEFGH",
+                      "CommUserid": "12345678",
+                      "CommFacilityName": "PAYAPI",
+                      "CommNetwrkId": "NET00001",
+                      "CommFaciltype": %d,
+                      "Fill0": ""
+                    },
+                    "CommSuccess": " ",
+                    "CommFailCode": " "
+                  }
+                }
+                """.formatted(amount, facilityType);
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
@@ -1,0 +1,126 @@
+package com.augment.cbsa.web.dbcrfun;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.DbcrfunOrigin;
+import com.augment.cbsa.domain.DbcrfunRequest;
+import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.DbcrfunService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DbcrfunController.class)
+@Import(CbsaExceptionHandler.class)
+class DbcrfunControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DbcrfunService dbcrfunService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(dbcrfunService.process(request(new BigDecimal("25.00"), 496))).thenReturn(DbcrfunResult.success(new AccountDetails(
+                "987654",
+                10L,
+                12345678L,
+                "ISA",
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal("525.00"),
+                new BigDecimal("525.00")
+        )));
+
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
+                .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
+                .andExpect(jsonPath("$.PAYDBCR.CommAvBal").value(525.00))
+                .andExpect(jsonPath("$.PAYDBCR.CommActBal").value(525.00))
+                .andExpect(jsonPath("$.PAYDBCR.CommOrigin.CommApplid").value("ABCDEFGH"))
+                .andExpect(jsonPath("$.PAYDBCR.CommSuccess").value("Y"));
+    }
+
+    @Test
+    void returnsProblemDetailForNotFoundFailures() throws Exception {
+        when(dbcrfunService.process(request(new BigDecimal("25.00"), 496)))
+                .thenReturn(DbcrfunResult.failure("1", "Account number 12345678 was not found."));
+
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Account not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsProblemDetailForConflictFailures() throws Exception {
+        when(dbcrfunService.process(request(new BigDecimal("-25.00"), 496)))
+                .thenReturn(DbcrfunResult.failure("3", "Account number 12345678 does not have sufficient available funds."));
+
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("Insufficient funds"))
+                .andExpect(jsonPath("$.failCode").value("3"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(missingAmountJson()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private DbcrfunRequest request(BigDecimal amount, int facilityType) {
+        return new DbcrfunRequest(12345678L, amount, new DbcrfunOrigin("ABCDEFGH", "12345678", "PAYAPI", "NET00001", facilityType, ""));
+    }
+
+    private String requestJson(String amount, int facilityType) {
+        return """
+                {
+                  "PAYDBCR": {
+                    "CommAccno": "12345678",
+                    "CommAmt": %s,
+                    "mSortC": 0,
+                    "CommAvBal": 0,
+                    "CommActBal": 0,
+                    "CommOrigin": {
+                      "CommApplid": "ABCDEFGH",
+                      "CommUserid": "12345678",
+                      "CommFacilityName": "PAYAPI",
+                      "CommNetwrkId": "NET00001",
+                      "CommFaciltype": %d,
+                      "Fill0": ""
+                    },
+                    "CommSuccess": " ",
+                    "CommFailCode": " "
+                  }
+                }
+                """.formatted(amount, facilityType);
+    }
+
+    private String missingAmountJson() {
+        return """
+                {
+                  "PAYDBCR": {
+                    "CommAccno": "12345678"
+                  }
+                }
+                """;
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,7 +47,7 @@ class DbcrfunControllerWebMvcTest {
                 new BigDecimal("525.00")
         )));
 
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
                 .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
@@ -62,7 +62,7 @@ class DbcrfunControllerWebMvcTest {
         when(dbcrfunService.process(request(new BigDecimal("25.00"), 496)))
                 .thenReturn(DbcrfunResult.failure("1", "Account number 12345678 was not found."));
 
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value("Account not found"))
                 .andExpect(jsonPath("$.failCode").value("1"));
@@ -73,7 +73,7 @@ class DbcrfunControllerWebMvcTest {
         when(dbcrfunService.process(request(new BigDecimal("-25.00"), 496)))
                 .thenReturn(DbcrfunResult.failure("3", "Account number 12345678 does not have sufficient available funds."));
 
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.title").value("Insufficient funds"))
                 .andExpect(jsonPath("$.failCode").value("3"));
@@ -81,7 +81,7 @@ class DbcrfunControllerWebMvcTest {
 
     @Test
     void requestValidationFailuresRemainProblemDetails() throws Exception {
-        mockMvc.perform(put("/api/v1/makepayment/dbcr").contentType(APPLICATION_JSON).content(missingAmountJson()))
+        mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(missingAmountJson()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("Validation failed"));
     }


### PR DESCRIPTION
## Source program
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/DBCRFUN.cbl

## Mapped REST endpoints
- POST /api/v1/dbcrfun

## Notable decisions
- Mapped the z/OS Connect PAYDBCR payload to POST /api/v1/dbcrfun, preserving the nested request/response shape and returning RFC-7807 ProblemDetail bodies for failures.
- Used CrdbRetry.run(...) around a transactional SELECT ... FOR UPDATE account lock so debit/credit updates follow CockroachDB retry requirements while matching the COBOL single-record update flow.
- Preserved DBCRFUN fail-code behavior with 1 for account not found, 2 for persistence/update failures, 3 for insufficient funds on payment debits, and 4 for payment-disallowed account types.
- Reused the existing AccountDetails domain model instead of introducing a duplicate account structure, and no Flyway migration was needed because DBCRFUN operates on existing account and proctran tables.
- Derived proctran audit entries from the amount sign and facility type, using PDR/PCR plus the origin-based payment description for payment traffic and DEB/CRE counter descriptions for non-payment facilities.
- CommOrigin (and CommFaciltype) are required on the request so clients explicitly opt into payment vs teller semantics rather than silently defaulting to non-payment when omitted.

## Test coverage
- Unit
- @SpringBootTest
- MockMvc