### PR TITLE
migrate(XFRFUN): translate transfer flow

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/XfrfunRequest.java
+++ b/src/main/java/com/augment/cbsa/domain/XfrfunRequest.java
@@ -1,0 +1,17 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+public record XfrfunRequest(
+        long fromAccountNumber,
+        long toAccountNumber,
+        BigDecimal amount
+) {
+
+    public XfrfunRequest {
+        Objects.requireNonNull(amount, "amount must not be null");
+        amount = amount.setScale(2, RoundingMode.HALF_EVEN);
+    }
+}

--- a/src/main/java/com/augment/cbsa/domain/XfrfunResult.java
+++ b/src/main/java/com/augment/cbsa/domain/XfrfunResult.java
@@ -1,0 +1,63 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record XfrfunResult(
+        boolean transferSuccess,
+        String failCode,
+        BigDecimal fromAvailableBalance,
+        BigDecimal fromActualBalance,
+        BigDecimal toAvailableBalance,
+        BigDecimal toActualBalance,
+        String message
+) {
+
+    public XfrfunResult {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+
+        if (transferSuccess) {
+            Objects.requireNonNull(fromAvailableBalance, "Successful results must include the from available balance");
+            Objects.requireNonNull(fromActualBalance, "Successful results must include the from actual balance");
+            Objects.requireNonNull(toAvailableBalance, "Successful results must include the to available balance");
+            Objects.requireNonNull(toActualBalance, "Successful results must include the to actual balance");
+            if (message != null && !message.isBlank()) {
+                throw new IllegalArgumentException("Successful results must not include a message");
+            }
+        } else {
+            if (fromAvailableBalance != null || fromActualBalance != null || toAvailableBalance != null || toActualBalance != null) {
+                throw new IllegalArgumentException("Failure results must not include balances");
+            }
+            if (message == null || message.isBlank()) {
+                throw new IllegalArgumentException("Failure results must include a non-blank message");
+            }
+        }
+    }
+
+    public static XfrfunResult success(
+            BigDecimal fromAvailableBalance,
+            BigDecimal fromActualBalance,
+            BigDecimal toAvailableBalance,
+            BigDecimal toActualBalance
+    ) {
+        return new XfrfunResult(true, "0", fromAvailableBalance, fromActualBalance, toAvailableBalance, toActualBalance, null);
+    }
+
+    public static XfrfunResult failure(String failCode, String message) {
+        Objects.requireNonNull(failCode, "failCode must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        return new XfrfunResult(false, failCode, null, null, null, null, message);
+    }
+
+    public boolean isFromAccountNotFoundFailure() {
+        return !transferSuccess && "1".equals(failCode);
+    }
+
+    public boolean isToAccountNotFoundFailure() {
+        return !transferSuccess && "2".equals(failCode);
+    }
+
+    public boolean isInvalidAmountFailure() {
+        return !transferSuccess && "4".equals(failCode);
+    }
+}

--- a/src/main/java/com/augment/cbsa/repository/XfrfunRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/XfrfunRepository.java
@@ -1,0 +1,95 @@
+package com.augment.cbsa.repository;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.jooq.tables.records.AccountRecord;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+
+@Repository
+public class XfrfunRepository {
+
+    private static final String TRANSFER_TYPE = "TFR";
+
+    private final DSLContext dsl;
+
+    public XfrfunRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    public Optional<AccountDetails> findBySortcodeAndAccountNumberForUpdate(String sortcode, long accountNumber) {
+        return dsl.selectFrom(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .forUpdate()
+                .fetchOptional(this::toDomain);
+    }
+
+    public int updateBalances(String sortcode, long accountNumber, BigDecimal availableBalance, BigDecimal actualBalance) {
+        return dsl.update(ACCOUNT)
+                .set(ACCOUNT.AVAILABLE_BALANCE, availableBalance)
+                .set(ACCOUNT.ACTUAL_BALANCE, actualBalance)
+                .where(ACCOUNT.SORTCODE.eq(sortcode))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(accountNumber))
+                .execute();
+    }
+
+    public void insertTransferAudit(
+            String fromSortcode,
+            long fromAccountNumber,
+            String toSortcode,
+            long toAccountNumber,
+            long transactionReference,
+            LocalDate transactionDate,
+            LocalTime transactionTime,
+            BigDecimal amount
+    ) {
+        Objects.requireNonNull(fromSortcode, "fromSortcode must not be null");
+        Objects.requireNonNull(toSortcode, "toSortcode must not be null");
+        Objects.requireNonNull(transactionDate, "transactionDate must not be null");
+        Objects.requireNonNull(transactionTime, "transactionTime must not be null");
+        Objects.requireNonNull(amount, "amount must not be null");
+
+        dsl.insertInto(PROCTRAN)
+                .set(PROCTRAN.SORTCODE, fromSortcode)
+                .set(PROCTRAN.LOGICAL_DELETE, false)
+                .set(PROCTRAN.TRAN_DATE, transactionDate)
+                .set(PROCTRAN.TRAN_TIME, transactionTime)
+                .set(PROCTRAN.TRAN_REF, transactionReference)
+                .set(PROCTRAN.TRAN_TYPE, TRANSFER_TYPE)
+                .set(PROCTRAN.DESCRIPTION, toTransferDescription(toSortcode, toAccountNumber))
+                .set(PROCTRAN.AMOUNT, amount)
+                .execute();
+    }
+
+    private AccountDetails toDomain(AccountRecord record) {
+        return new AccountDetails(
+                record.getSortcode(),
+                record.getCustomerNumber(),
+                record.getAccountNumber(),
+                record.getAccountType(),
+                record.getInterestRate(),
+                record.getOpened(),
+                record.getOverdraftLimit(),
+                record.getLastStmtDate(),
+                record.getNextStmtDate(),
+                record.getAvailableBalance(),
+                record.getActualBalance()
+        );
+    }
+
+    private String toTransferDescription(String toSortcode, long toAccountNumber) {
+        if (toSortcode.length() != 6) {
+            throw new IllegalArgumentException("toSortcode must be exactly 6 characters");
+        }
+        return String.format(Locale.ROOT, "%-26.26s%s%08d", "TRANSFER", toSortcode, toAccountNumber);
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/XfrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/XfrfunService.java
@@ -33,6 +33,7 @@ public class XfrfunService {
     private static final String FROM_ACCOUNT_ABEND_CODE = "FROM";
     private static final String TO_ACCOUNT_ABEND_CODE = "TO  ";
     private static final String PROCTRAN_ABEND_CODE = "WPCD";
+    private static final String RETRY_EXHAUSTED_ABEND_CODE = "XRTY";
 
     private final XfrfunRepository xfrfunRepository;
     private final DSLContext dsl;
@@ -66,10 +67,21 @@ public class XfrfunService {
         }
 
         Instant now = Instant.now(clock);
-        return Objects.requireNonNull(
-                CrdbRetry.run(dsl, () -> transactionTemplate.execute(status -> transferWithinTransaction(request, now))),
-                "transactionTemplate returned null result"
-        );
+        try {
+            return Objects.requireNonNull(
+                    CrdbRetry.run(dsl, () -> transactionTemplate.execute(status -> transferWithinTransaction(request, now))),
+                    "transactionTemplate returned null result"
+            );
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw new CbsaAbendException(
+                        RETRY_EXHAUSTED_ABEND_CODE,
+                        "XFRFUN aborted after exhausting Cockroach serialization retries.",
+                        exception
+                );
+            }
+            throw exception;
+        }
     }
 
     private XfrfunResult transferWithinTransaction(XfrfunRequest request, Instant now) {
@@ -119,8 +131,18 @@ public class XfrfunService {
             return OrderedAccounts.success(fromAccount.get(), toAccount.get());
         }
 
+        // fromAccountNumber > toAccountNumber: lock TO first to preserve a consistent
+        // global lock order, but mirror COBOL's failure precedence (FROM-not-found wins
+        // over TO-not-found) by probing the FROM row when the TO row is missing.
         Optional<AccountDetails> toAccount = findAccountForUpdate(TO_ACCOUNT_ABEND_CODE, "TO", request.toAccountNumber());
         if (toAccount.isEmpty()) {
+            Optional<AccountDetails> fromProbe = findAccountForUpdate(FROM_ACCOUNT_ABEND_CODE, "FROM", request.fromAccountNumber());
+            if (fromProbe.isEmpty()) {
+                return OrderedAccounts.failure(XfrfunResult.failure(
+                        FROM_ACCOUNT_NOT_FOUND_CODE,
+                        "From account number %d was not found.".formatted(request.fromAccountNumber())
+                ));
+            }
             return OrderedAccounts.failure(XfrfunResult.failure(
                     TO_ACCOUNT_NOT_FOUND_CODE,
                     "To account number %d was not found.".formatted(request.toAccountNumber())

--- a/src/main/java/com/augment/cbsa/service/XfrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/XfrfunService.java
@@ -1,0 +1,229 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.XfrfunRequest;
+import com.augment.cbsa.domain.XfrfunResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.CrdbRetry;
+import com.augment.cbsa.repository.XfrfunRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class XfrfunService {
+
+    private static final String FROM_ACCOUNT_NOT_FOUND_CODE = "1";
+    private static final String TO_ACCOUNT_NOT_FOUND_CODE = "2";
+    private static final String INVALID_AMOUNT_CODE = "4";
+    private static final String SAME_ACCOUNT_ABEND_CODE = "SAME";
+    private static final String FROM_ACCOUNT_ABEND_CODE = "FROM";
+    private static final String TO_ACCOUNT_ABEND_CODE = "TO  ";
+    private static final String PROCTRAN_ABEND_CODE = "WPCD";
+
+    private final XfrfunRepository xfrfunRepository;
+    private final DSLContext dsl;
+    private final TransactionTemplate transactionTemplate;
+    private final String sortcode;
+    private final Clock clock;
+
+    public XfrfunService(
+            XfrfunRepository xfrfunRepository,
+            DSLContext dsl,
+            TransactionTemplate transactionTemplate,
+            @Value("${cbsa.sortcode}") String sortcode,
+            Clock clock
+    ) {
+        this.xfrfunRepository = Objects.requireNonNull(xfrfunRepository, "xfrfunRepository must not be null");
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+        this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    public XfrfunResult transfer(XfrfunRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        if (request.amount().signum() <= 0) {
+            return XfrfunResult.failure(INVALID_AMOUNT_CODE, "Please supply an amount greater than zero.");
+        }
+
+        if (request.fromAccountNumber() == request.toAccountNumber()) {
+            throw new CbsaAbendException(SAME_ACCOUNT_ABEND_CODE, "XFRFUN cannot transfer funds to the same account.");
+        }
+
+        Instant now = Instant.now(clock);
+        return Objects.requireNonNull(
+                CrdbRetry.run(dsl, () -> transactionTemplate.execute(status -> transferWithinTransaction(request, now))),
+                "transactionTemplate returned null result"
+        );
+    }
+
+    private XfrfunResult transferWithinTransaction(XfrfunRequest request, Instant now) {
+        OrderedAccounts orderedAccounts = lockAccountsInDeterministicOrder(request);
+        if (orderedAccounts.failure() != null) {
+            return orderedAccounts.failure();
+        }
+
+        AccountDetails fromAccount = Objects.requireNonNull(orderedAccounts.fromAccount(), "fromAccount must not be null");
+        AccountDetails toAccount = Objects.requireNonNull(orderedAccounts.toAccount(), "toAccount must not be null");
+
+        BigDecimal updatedFromAvailableBalance = scale(fromAccount.availableBalance().subtract(request.amount()));
+        BigDecimal updatedFromActualBalance = scale(fromAccount.actualBalance().subtract(request.amount()));
+        BigDecimal updatedToAvailableBalance = scale(toAccount.availableBalance().add(request.amount()));
+        BigDecimal updatedToActualBalance = scale(toAccount.actualBalance().add(request.amount()));
+
+        updateAccountOrThrow(FROM_ACCOUNT_ABEND_CODE, "FROM", fromAccount.accountNumber(), updatedFromAvailableBalance, updatedFromActualBalance);
+        updateAccountOrThrow(TO_ACCOUNT_ABEND_CODE, "TO", toAccount.accountNumber(), updatedToAvailableBalance, updatedToActualBalance);
+        insertAuditOrThrow(request, now);
+
+        return XfrfunResult.success(
+                updatedFromAvailableBalance,
+                updatedFromActualBalance,
+                updatedToAvailableBalance,
+                updatedToActualBalance
+        );
+    }
+
+    private OrderedAccounts lockAccountsInDeterministicOrder(XfrfunRequest request) {
+        if (request.fromAccountNumber() < request.toAccountNumber()) {
+            Optional<AccountDetails> fromAccount = findAccountForUpdate(FROM_ACCOUNT_ABEND_CODE, "FROM", request.fromAccountNumber());
+            if (fromAccount.isEmpty()) {
+                return OrderedAccounts.failure(XfrfunResult.failure(
+                        FROM_ACCOUNT_NOT_FOUND_CODE,
+                        "From account number %d was not found.".formatted(request.fromAccountNumber())
+                ));
+            }
+
+            Optional<AccountDetails> toAccount = findAccountForUpdate(TO_ACCOUNT_ABEND_CODE, "TO", request.toAccountNumber());
+            if (toAccount.isEmpty()) {
+                return OrderedAccounts.failure(XfrfunResult.failure(
+                        TO_ACCOUNT_NOT_FOUND_CODE,
+                        "To account number %d was not found.".formatted(request.toAccountNumber())
+                ));
+            }
+
+            return OrderedAccounts.success(fromAccount.get(), toAccount.get());
+        }
+
+        Optional<AccountDetails> toAccount = findAccountForUpdate(TO_ACCOUNT_ABEND_CODE, "TO", request.toAccountNumber());
+        if (toAccount.isEmpty()) {
+            return OrderedAccounts.failure(XfrfunResult.failure(
+                    TO_ACCOUNT_NOT_FOUND_CODE,
+                    "To account number %d was not found.".formatted(request.toAccountNumber())
+            ));
+        }
+
+        Optional<AccountDetails> fromAccount = findAccountForUpdate(FROM_ACCOUNT_ABEND_CODE, "FROM", request.fromAccountNumber());
+        if (fromAccount.isEmpty()) {
+            return OrderedAccounts.failure(XfrfunResult.failure(
+                    FROM_ACCOUNT_NOT_FOUND_CODE,
+                    "From account number %d was not found.".formatted(request.fromAccountNumber())
+            ));
+        }
+
+        return OrderedAccounts.success(fromAccount.get(), toAccount.get());
+    }
+
+    private Optional<AccountDetails> findAccountForUpdate(String abendCode, String accountRole, long accountNumber) {
+        try {
+            return xfrfunRepository.findBySortcodeAndAccountNumberForUpdate(sortcode, accountNumber);
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(
+                    abendCode,
+                    "XFRFUN failed while reading the %s account %d.".formatted(accountRole, accountNumber),
+                    exception
+            );
+        }
+    }
+
+    private void updateAccountOrThrow(
+            String abendCode,
+            String accountRole,
+            long accountNumber,
+            BigDecimal availableBalance,
+            BigDecimal actualBalance
+    ) {
+        try {
+            int updatedRows = xfrfunRepository.updateBalances(sortcode, accountNumber, availableBalance, actualBalance);
+            if (updatedRows != 1) {
+                throw new CbsaAbendException(
+                        abendCode,
+                        "XFRFUN unexpectedly updated %d %s account rows for account %d."
+                                .formatted(updatedRows, accountRole, accountNumber)
+                );
+            }
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(
+                    abendCode,
+                    "XFRFUN failed while updating the %s account %d.".formatted(accountRole, accountNumber),
+                    exception
+            );
+        }
+    }
+
+    private void insertAuditOrThrow(XfrfunRequest request, Instant now) {
+        try {
+            xfrfunRepository.insertTransferAudit(
+                    sortcode,
+                    request.fromAccountNumber(),
+                    sortcode,
+                    request.toAccountNumber(),
+                    Math.max(0L, now.toEpochMilli()),
+                    LocalDate.ofInstant(now, ZoneOffset.UTC),
+                    LocalTime.ofInstant(now, ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS),
+                    request.amount()
+            );
+        } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(PROCTRAN_ABEND_CODE, "XFRFUN failed to write the transfer audit trail.", exception);
+        }
+    }
+
+    private BigDecimal scale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private record OrderedAccounts(AccountDetails fromAccount, AccountDetails toAccount, XfrfunResult failure) {
+
+        private static OrderedAccounts success(AccountDetails fromAccount, AccountDetails toAccount) {
+            return new OrderedAccounts(fromAccount, toAccount, null);
+        }
+
+        private static OrderedAccounts failure(XfrfunResult failure) {
+            return new OrderedAccounts(null, null, failure);
+        }
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
@@ -1,0 +1,94 @@
+package com.augment.cbsa.web.xfrfun;
+
+import com.augment.cbsa.domain.XfrfunRequest;
+import com.augment.cbsa.domain.XfrfunResult;
+import com.augment.cbsa.service.XfrfunService;
+import com.augment.cbsa.web.xfrfun.dto.XfrfunCommareaRequestDto;
+import com.augment.cbsa.web.xfrfun.dto.XfrfunCommareaResponseDto;
+import com.augment.cbsa.web.xfrfun.dto.XfrfunRequestDto;
+import com.augment.cbsa.web.xfrfun.dto.XfrfunResponseDto;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/xfrfun")
+public class XfrfunController {
+
+    private final XfrfunService xfrfunService;
+    private final String sortcode;
+
+    public XfrfunController(XfrfunService xfrfunService, @Value("${cbsa.sortcode}") String sortcode) {
+        this.xfrfunService = Objects.requireNonNull(xfrfunService, "xfrfunService must not be null");
+        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+    }
+
+    @PostMapping
+    public ResponseEntity<?> transfer(@Valid @RequestBody XfrfunRequestDto requestDto) {
+        XfrfunCommareaRequestDto commarea = requestDto.xfrfun();
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(
+                commarea.commFaccno(),
+                commarea.commTaccno(),
+                commarea.commAmt()
+        ));
+
+        if (!result.transferSuccess()) {
+            return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
+        }
+
+        return ResponseEntity.ok(new XfrfunResponseDto(new XfrfunCommareaResponseDto(
+                commarea.commFaccno(),
+                Integer.parseInt(sortcode),
+                commarea.commTaccno(),
+                Integer.parseInt(sortcode),
+                commarea.commAmt(),
+                result.fromAvailableBalance(),
+                result.fromActualBalance(),
+                result.toAvailableBalance(),
+                result.toActualBalance(),
+                "0",
+                "Y"
+        )));
+    }
+
+    private HttpStatus failureStatus(XfrfunResult result) {
+        if (result.isFromAccountNotFoundFailure() || result.isToAccountNotFoundFailure()) {
+            return HttpStatus.NOT_FOUND;
+        }
+        if (result.isInvalidAmountFailure()) {
+            return HttpStatus.BAD_REQUEST;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private ProblemDetail failureBody(XfrfunResult result) {
+        HttpStatus status = failureStatus(result);
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle(failureTitle(result));
+        problemDetail.setDetail(result.message());
+        problemDetail.setProperty("failCode", result.failCode());
+        return problemDetail;
+    }
+
+    private String failureTitle(XfrfunResult result) {
+        if (result.isFromAccountNotFoundFailure()) {
+            return "From account not found";
+        }
+        if (result.isToAccountNotFoundFailure()) {
+            return "To account not found";
+        }
+        if (result.isInvalidAmountFailure()) {
+            return "Invalid transfer amount";
+        }
+        return "Transfer failed";
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
@@ -35,11 +35,12 @@ public class XfrfunController {
     @PostMapping
     public ResponseEntity<?> transfer(@Valid @RequestBody XfrfunRequestDto requestDto) {
         XfrfunCommareaRequestDto commarea = requestDto.xfrfun();
-        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(
+        XfrfunRequest serviceRequest = new XfrfunRequest(
                 commarea.commFaccno(),
                 commarea.commTaccno(),
                 commarea.commAmt()
-        ));
+        );
+        XfrfunResult result = xfrfunService.transfer(serviceRequest);
 
         if (!result.transferSuccess()) {
             return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
@@ -50,7 +51,7 @@ public class XfrfunController {
                 Integer.parseInt(sortcode),
                 commarea.commTaccno(),
                 Integer.parseInt(sortcode),
-                commarea.commAmt(),
+                serviceRequest.amount(),
                 result.fromAvailableBalance(),
                 result.fromActualBalance(),
                 result.toAvailableBalance(),

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
@@ -1,0 +1,44 @@
+package com.augment.cbsa.web.xfrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record XfrfunCommareaRequestDto(
+        @JsonProperty("CommFaccno")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999L)
+        Long commFaccno,
+
+        @JsonProperty("CommFscode")
+        @NotNull
+        @Min(0)
+        @Max(999_999)
+        Integer commFscode,
+
+        @JsonProperty("CommTaccno")
+        @NotNull
+        @Min(0)
+        @Max(99_999_999L)
+        Long commTaccno,
+
+        @JsonProperty("CommTscode")
+        @NotNull
+        @Min(0)
+        @Max(999_999)
+        Integer commTscode,
+
+        @JsonProperty("CommAmt")
+        @NotNull
+        @Digits(integer = 10, fraction = 2)
+        @DecimalMin("-9999999999.99")
+        @DecimalMax("9999999999.99")
+        BigDecimal commAmt
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaResponseDto.java
@@ -1,0 +1,40 @@
+package com.augment.cbsa.web.xfrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public record XfrfunCommareaResponseDto(
+        @JsonProperty("CommFaccno")
+        long commFaccno,
+
+        @JsonProperty("CommFscode")
+        int commFscode,
+
+        @JsonProperty("CommTaccno")
+        long commTaccno,
+
+        @JsonProperty("CommTscode")
+        int commTscode,
+
+        @JsonProperty("CommAmt")
+        BigDecimal commAmt,
+
+        @JsonProperty("CommFavbal")
+        BigDecimal commFavbal,
+
+        @JsonProperty("CommFactbal")
+        BigDecimal commFactbal,
+
+        @JsonProperty("CommTavbal")
+        BigDecimal commTavbal,
+
+        @JsonProperty("CommTactbal")
+        BigDecimal commTactbal,
+
+        @JsonProperty("CommFailCode")
+        String commFailCode,
+
+        @JsonProperty("CommSuccess")
+        String commSuccess
+) {
+}

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.xfrfun.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record XfrfunRequestDto(
         @JsonProperty("XFRFUN")
@@ -11,8 +10,4 @@ public record XfrfunRequestDto(
         @NotNull
         XfrfunCommareaRequestDto xfrfun
 ) {
-
-    public XfrfunRequestDto {
-        Objects.requireNonNull(xfrfun, "xfrfun must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunRequestDto.java
@@ -1,0 +1,18 @@
+package com.augment.cbsa.web.xfrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record XfrfunRequestDto(
+        @JsonProperty("XFRFUN")
+        @Valid
+        @NotNull
+        XfrfunCommareaRequestDto xfrfun
+) {
+
+    public XfrfunRequestDto {
+        Objects.requireNonNull(xfrfun, "xfrfun must not be null");
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunResponseDto.java
@@ -1,0 +1,14 @@
+package com.augment.cbsa.web.xfrfun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public record XfrfunResponseDto(
+        @JsonProperty("XFRFUN")
+        XfrfunCommareaResponseDto xfrfun
+) {
+
+    public XfrfunResponseDto {
+        Objects.requireNonNull(xfrfun, "xfrfun must not be null");
+    }
+}

--- a/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
+++ b/src/test/java/com/augment/cbsa/CbsaApplicationTests.java
@@ -9,9 +9,11 @@ import com.augment.cbsa.repository.DelcusRepository;
 import com.augment.cbsa.repository.CustomerRepository;
 import com.augment.cbsa.repository.UpdaccRepository;
 import com.augment.cbsa.repository.UpdcustRepository;
+import com.augment.cbsa.repository.XfrfunRepository;
 import com.augment.cbsa.service.DelaccService;
 import com.augment.cbsa.service.DbcrfunService;
 import com.augment.cbsa.service.DelcusService;
+import com.augment.cbsa.service.XfrfunService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -60,6 +62,9 @@ class CbsaApplicationTests {
     private DbcrfunRepository dbcrfunRepository;
 
     @MockitoBean
+    private XfrfunRepository xfrfunRepository;
+
+    @MockitoBean
     private DelcusService delcusService;
 
     @MockitoBean
@@ -67,6 +72,9 @@ class CbsaApplicationTests {
 
     @MockitoBean
     private DbcrfunService dbcrfunService;
+
+    @MockitoBean
+    private XfrfunService xfrfunService;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/augment/cbsa/service/XfrfunServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/XfrfunServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.XfrfunRequest;
+import com.augment.cbsa.domain.XfrfunResult;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.augment.cbsa.jooq.Tables.ACCOUNT;
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
+import static com.augment.cbsa.jooq.Tables.PROCTRAN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class XfrfunServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private XfrfunService xfrfunService;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private Clock clock;
+
+    @BeforeEach
+    void cleanDatabase() {
+        dsl.deleteFrom(PROCTRAN).execute();
+        dsl.deleteFrom(ACCOUNT).execute();
+        dsl.deleteFrom(CUSTOMER).execute();
+    }
+
+    @Test
+    void transfersFundsAndWritesTransferAudit() {
+        insertCustomer(10L);
+        insertCustomer(20L);
+        insertAccount(10L, 12345678L, new BigDecimal("500.00"));
+        insertAccount(20L, 87654321L, new BigDecimal("150.00"));
+
+        LocalDate today = LocalDate.now(clock);
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00")));
+
+        assertThat(result.transferSuccess()).isTrue();
+        assertThat(result.fromAvailableBalance()).isEqualByComparingTo("475.00");
+        assertThat(result.toAvailableBalance()).isEqualByComparingTo("175.00");
+
+        assertThat(dsl.select(ACCOUNT.AVAILABLE_BALANCE)
+                .from(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchSingle(ACCOUNT.AVAILABLE_BALANCE)).isEqualTo(new BigDecimal("475.00"));
+        assertThat(dsl.select(ACCOUNT.AVAILABLE_BALANCE)
+                .from(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(87654321L))
+                .fetchSingle(ACCOUNT.AVAILABLE_BALANCE)).isEqualTo(new BigDecimal("175.00"));
+
+        var auditRow = dsl.select(PROCTRAN.TRAN_TYPE, PROCTRAN.DESCRIPTION, PROCTRAN.AMOUNT, PROCTRAN.TRAN_DATE)
+                .from(PROCTRAN)
+                .fetchSingle();
+        assertThat(auditRow.get(PROCTRAN.TRAN_TYPE)).isEqualTo("TFR");
+        assertThat(auditRow.get(PROCTRAN.DESCRIPTION)).isEqualTo(String.format("%-26.26s%s%08d", "TRANSFER", "987654", 87654321L));
+        assertThat(auditRow.get(PROCTRAN.AMOUNT)).isEqualTo(new BigDecimal("25.00"));
+        assertThat(auditRow.get(PROCTRAN.TRAN_DATE)).isIn(today, today.plusDays(1));
+    }
+
+    @Test
+    void returnsToAccountNotFoundWithoutChangingTheFromAccount() {
+        insertCustomer(10L);
+        insertAccount(10L, 12345678L, new BigDecimal("500.00"));
+
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00")));
+
+        assertThat(result.transferSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(dsl.select(ACCOUNT.AVAILABLE_BALANCE)
+                .from(ACCOUNT)
+                .where(ACCOUNT.SORTCODE.eq("987654"))
+                .and(ACCOUNT.ACCOUNT_NUMBER.eq(12345678L))
+                .fetchSingle(ACCOUNT.AVAILABLE_BALANCE)).isEqualTo(new BigDecimal("500.00"));
+        assertThat(dsl.fetchCount(PROCTRAN)).isZero();
+    }
+
+    private void insertCustomer(long customerNumber) {
+        dsl.insertInto(CUSTOMER)
+                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
+                .set(CUSTOMER.NAME, "Example Customer")
+                .set(CUSTOMER.ADDRESS, "1 Example Road")
+                .set(CUSTOMER.DATE_OF_BIRTH, LocalDate.of(1990, 1, 1))
+                .set(CUSTOMER.CREDIT_SCORE, (short) 500)
+                .set(CUSTOMER.CS_REVIEW_DATE, LocalDate.of(2025, 1, 1))
+                .execute();
+    }
+
+    private void insertAccount(long customerNumber, long accountNumber, BigDecimal balance) {
+        dsl.insertInto(ACCOUNT)
+                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
+                .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
+                .set(ACCOUNT.ACCOUNT_TYPE, "ISA")
+                .set(ACCOUNT.INTEREST_RATE, new BigDecimal("1.50"))
+                .set(ACCOUNT.OPENED, LocalDate.of(2024, 1, 2))
+                .set(ACCOUNT.OVERDRAFT_LIMIT, new BigDecimal("250.00"))
+                .set(ACCOUNT.LAST_STMT_DATE, LocalDate.of(2024, 2, 3))
+                .set(ACCOUNT.NEXT_STMT_DATE, LocalDate.of(2024, 3, 4))
+                .set(ACCOUNT.AVAILABLE_BALANCE, balance)
+                .set(ACCOUNT.ACTUAL_BALANCE, balance)
+                .execute();
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
@@ -1,0 +1,165 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.domain.XfrfunRequest;
+import com.augment.cbsa.domain.XfrfunResult;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.repository.XfrfunRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class XfrfunServiceUnitTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-01T10:15:30Z"), ZoneOffset.UTC);
+
+    private XfrfunRepository xfrfunRepository;
+    private XfrfunService xfrfunService;
+
+    @BeforeEach
+    void setUp() {
+        xfrfunRepository = mock(XfrfunRepository.class);
+        DSLContext dsl = mock(DSLContext.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            TransactionCallback<XfrfunResult> callback = invocation.getArgument(0, TransactionCallback.class);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
+        xfrfunService = new XfrfunService(xfrfunRepository, dsl, transactionTemplate, "987654", FIXED_CLOCK);
+    }
+
+    @Test
+    void rejectsNullRequestWithClearMessage() {
+        assertThatThrownBy(() -> xfrfunService.transfer(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("request must not be null");
+        verifyNoInteractions(xfrfunRepository);
+    }
+
+    @Test
+    void returnsValidationFailureWhenAmountIsZeroOrNegative() {
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, BigDecimal.ZERO));
+
+        assertThat(result.transferSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("4");
+        assertThat(result.message()).isEqualTo("Please supply an amount greater than zero.");
+        verifyNoInteractions(xfrfunRepository);
+    }
+
+    @Test
+    void abendsWhenTransferTargetsTheSameAccount() {
+        assertThatThrownBy(() -> xfrfunService.transfer(new XfrfunRequest(12345678L, 12345678L, new BigDecimal("25.00"))))
+                .isInstanceOf(CbsaAbendException.class)
+                .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
+                .isEqualTo("SAME");
+        verifyNoInteractions(xfrfunRepository);
+    }
+
+    @Test
+    void returnsFromAccountNotFoundWhenDebitAccountDoesNotExist() {
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 12345678L)).thenReturn(Optional.empty());
+
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00")));
+
+        assertThat(result.transferSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("1");
+        assertThat(result.message()).isEqualTo("From account number 12345678 was not found.");
+    }
+
+    @Test
+    void returnsToAccountNotFoundWhenCreditAccountDoesNotExist() {
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 12345678L)).thenReturn(Optional.of(account(12345678L, "100.00")));
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 87654321L)).thenReturn(Optional.empty());
+
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00")));
+
+        assertThat(result.transferSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("2");
+        assertThat(result.message()).isEqualTo("To account number 87654321 was not found.");
+    }
+
+    @Test
+    void locksLowerAccountFirstAndWritesTransferAuditOnSuccess() {
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 11111111L)).thenReturn(Optional.of(account(11111111L, "50.00")));
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 22222222L)).thenReturn(Optional.of(account(22222222L, "10.00")));
+        when(xfrfunRepository.updateBalances("987654", 22222222L, new BigDecimal("-15.00"), new BigDecimal("-15.00"))).thenReturn(1);
+        when(xfrfunRepository.updateBalances("987654", 11111111L, new BigDecimal("75.00"), new BigDecimal("75.00"))).thenReturn(1);
+
+        XfrfunResult result = xfrfunService.transfer(new XfrfunRequest(22222222L, 11111111L, new BigDecimal("25.00")));
+
+        assertThat(result.transferSuccess()).isTrue();
+        assertThat(result.fromAvailableBalance()).isEqualByComparingTo("-15.00");
+        assertThat(result.toAvailableBalance()).isEqualByComparingTo("75.00");
+
+        InOrder inOrder = inOrder(xfrfunRepository);
+        inOrder.verify(xfrfunRepository).findBySortcodeAndAccountNumberForUpdate("987654", 11111111L);
+        inOrder.verify(xfrfunRepository).findBySortcodeAndAccountNumberForUpdate("987654", 22222222L);
+        inOrder.verify(xfrfunRepository).updateBalances("987654", 22222222L, new BigDecimal("-15.00"), new BigDecimal("-15.00"));
+        inOrder.verify(xfrfunRepository).updateBalances("987654", 11111111L, new BigDecimal("75.00"), new BigDecimal("75.00"));
+        verify(xfrfunRepository).insertTransferAudit(
+                eq("987654"),
+                eq(22222222L),
+                eq("987654"),
+                eq(11111111L),
+                anyLong(),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalTime.of(10, 15, 30)),
+                eq(new BigDecimal("25.00"))
+        );
+    }
+
+    @Test
+    void wrapsAuditFailuresInWpcdAbend() {
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 12345678L)).thenReturn(Optional.of(account(12345678L, "100.00")));
+        when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 87654321L)).thenReturn(Optional.of(account(87654321L, "10.00")));
+        when(xfrfunRepository.updateBalances("987654", 12345678L, new BigDecimal("75.00"), new BigDecimal("75.00"))).thenReturn(1);
+        when(xfrfunRepository.updateBalances("987654", 87654321L, new BigDecimal("35.00"), new BigDecimal("35.00"))).thenReturn(1);
+        org.mockito.Mockito.doThrow(new DataAccessException("audit failed") {
+        }).when(xfrfunRepository).insertTransferAudit(eq("987654"), eq(12345678L), eq("987654"), eq(87654321L), anyLong(), any(LocalDate.class), any(LocalTime.class), eq(new BigDecimal("25.00")));
+
+        assertThatThrownBy(() -> xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00"))))
+                .isInstanceOf(CbsaAbendException.class)
+                .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
+                .isEqualTo("WPCD");
+    }
+
+    private AccountDetails account(long accountNumber, String balance) {
+        return new AccountDetails(
+                "987654",
+                10L,
+                accountNumber,
+                "ISA",
+                new BigDecimal("1.50"),
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("250.00"),
+                LocalDate.of(2024, 2, 3),
+                LocalDate.of(2024, 3, 4),
+                new BigDecimal(balance),
+                new BigDecimal(balance)
+        );
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/xfrfun/XfrfunControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/xfrfun/XfrfunControllerWebMvcTest.java
@@ -1,0 +1,95 @@
+package com.augment.cbsa.web.xfrfun;
+
+import com.augment.cbsa.domain.XfrfunRequest;
+import com.augment.cbsa.domain.XfrfunResult;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.XfrfunService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(XfrfunController.class)
+@Import(CbsaExceptionHandler.class)
+@TestPropertySource(properties = "cbsa.sortcode=987654")
+class XfrfunControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private XfrfunService xfrfunService;
+
+    @Test
+    void returnsSuccessfulResponseForHappyPath() throws Exception {
+        when(xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00"))))
+                .thenReturn(XfrfunResult.success(
+                        new BigDecimal("475.00"),
+                        new BigDecimal("475.00"),
+                        new BigDecimal("175.00"),
+                        new BigDecimal("175.00")
+                ));
+
+        mockMvc.perform(post("/api/v1/xfrfun").contentType(APPLICATION_JSON).content(requestJson("25.00")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.XFRFUN.CommFaccno").value(12345678))
+                .andExpect(jsonPath("$.XFRFUN.CommFscode").value(987654))
+                .andExpect(jsonPath("$.XFRFUN.CommTaccno").value(87654321))
+                .andExpect(jsonPath("$.XFRFUN.CommTavbal").value(175.00))
+                .andExpect(jsonPath("$.XFRFUN.CommSuccess").value("Y"));
+    }
+
+    @Test
+    void returnsNotFoundProblemDetailWhenFromAccountIsMissing() throws Exception {
+        when(xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00"))))
+                .thenReturn(XfrfunResult.failure("1", "From account number 12345678 was not found."));
+
+        mockMvc.perform(post("/api/v1/xfrfun").contentType(APPLICATION_JSON).content(requestJson("25.00")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("From account not found"))
+                .andExpect(jsonPath("$.failCode").value("1"));
+    }
+
+    @Test
+    void returnsBadRequestProblemDetailForBusinessValidationFailures() throws Exception {
+        when(xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("0.00"))))
+                .thenReturn(XfrfunResult.failure("4", "Please supply an amount greater than zero."));
+
+        mockMvc.perform(post("/api/v1/xfrfun").contentType(APPLICATION_JSON).content(requestJson("0.00")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Invalid transfer amount"))
+                .andExpect(jsonPath("$.failCode").value("4"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(post("/api/v1/xfrfun").contentType(APPLICATION_JSON).content("{\"XFRFUN\":{\"CommFaccno\":12345678}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    private String requestJson(String amount) {
+        return """
+                {
+                  "XFRFUN": {
+                    "CommFaccno": 12345678,
+                    "CommFscode": 111111,
+                    "CommTaccno": 87654321,
+                    "CommTscode": 222222,
+                    "CommAmt": %s
+                  }
+                }
+                """.formatted(amount);
+    }
+}


### PR DESCRIPTION
**Source program**: https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/XFRFUN.cbl

**Mapped REST endpoints**
- POST /api/v1/xfrfun

**Notable decisions**
- Locked the two accounts in ascending account-number order before updating balances to prevent cross-transfer deadlocks while preserving the COBOL program flow.
- Reused the existing ACCOUNT and PROCTRAN tables, so no Flyway migration was needed for XFRFUN.
- Mapped COBOL fail-code outcomes to typed XfrfunResult failures and surfaced them as RFC-7807 ProblemDetail responses for 400/404 cases.
- Treated same-account transfers and database write/read anomalies as typed CbsaAbendException failures with distinct abend codes.
- Wrote a fixed-width PROCTRAN audit description containing the destination sort code and account number, matching the established audit-trail conventions in the codebase.
- Wrapped the transactional transfer flow in the existing Cockroach retry helper so serialization failures (SQLSTATE 40001) retry safely.

**Test coverage**
- Unit: XfrfunServiceUnitTest
- @SpringBootTest: XfrfunServiceIntegrationTest
- MockMvc: XfrfunControllerWebMvcTest
