### PR TITLE
migrate(CRDTAGY): translate credit agency batch (1..5)

### DIFF
--- a/src/main/java/com/augment/cbsa/config/CbsaAsyncConfig.java
+++ b/src/main/java/com/augment/cbsa/config/CbsaAsyncConfig.java
@@ -1,7 +1,11 @@
 package com.augment.cbsa.config;
 
+import com.augment.cbsa.service.CreditAgencyDelayExecutor;
+import com.augment.cbsa.service.CreditAgencyDelayGenerator;
+import com.augment.cbsa.service.CreditAgencyScoreGenerator;
 import java.time.Clock;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.VirtualThreadTaskExecutor;
@@ -14,6 +18,27 @@ public class CbsaAsyncConfig {
     @Bean(name = "creditAgencyExecutor")
     VirtualThreadTaskExecutor creditAgencyExecutor() {
         return new VirtualThreadTaskExecutor("credit-agency-");
+    }
+
+    @Bean
+    CreditAgencyDelayGenerator creditAgencyDelayGenerator() {
+        return agency -> java.time.Duration.ofSeconds(ThreadLocalRandom.current().nextLong(
+                agency.minimumDelaySeconds(),
+                agency.maximumDelaySecondsExclusive()
+        ));
+    }
+
+    @Bean
+    CreditAgencyScoreGenerator creditAgencyScoreGenerator() {
+        // Mirror the COBOL COMPUTE into an integer PIC 999 field: nextInt(1, 999)
+        // yields 1..998, matching the source program's effective upper bound once
+        // the fractional RANDOM result is truncated into the receiving integer.
+        return (agency, request) -> ThreadLocalRandom.current().nextInt(1, 999);
+    }
+
+    @Bean
+    CreditAgencyDelayExecutor creditAgencyDelayExecutor() {
+        return duration -> Thread.sleep(duration);
     }
 
     @Bean

--- a/src/main/java/com/augment/cbsa/domain/CreditAgency.java
+++ b/src/main/java/com/augment/cbsa/domain/CreditAgency.java
@@ -1,0 +1,59 @@
+package com.augment.cbsa.domain;
+
+import java.util.Arrays;
+
+public enum CreditAgency {
+
+    CRDTAGY1(1, "CRDTAGY1", "CIPA", 1, 3),
+    CRDTAGY2(2, "CRDTAGY2", "CIPB", 1, 3),
+    CRDTAGY3(3, "CRDTAGY3", "CIPC", 1, 3),
+    CRDTAGY4(4, "CRDTAGY4", "CIPD", 1, 3),
+    CRDTAGY5(5, "CRDTAGY5", "CIPE", 1, 3);
+
+    private final int agencyNumber;
+    private final String programName;
+    private final String containerName;
+    private final int minimumDelaySeconds;
+    private final int maximumDelaySecondsExclusive;
+
+    CreditAgency(
+            int agencyNumber,
+            String programName,
+            String containerName,
+            int minimumDelaySeconds,
+            int maximumDelaySecondsExclusive
+    ) {
+        this.agencyNumber = agencyNumber;
+        this.programName = programName;
+        this.containerName = containerName;
+        this.minimumDelaySeconds = minimumDelaySeconds;
+        this.maximumDelaySecondsExclusive = maximumDelaySecondsExclusive;
+    }
+
+    public int agencyNumber() {
+        return agencyNumber;
+    }
+
+    public String programName() {
+        return programName;
+    }
+
+    public String containerName() {
+        return containerName;
+    }
+
+    public int minimumDelaySeconds() {
+        return minimumDelaySeconds;
+    }
+
+    public int maximumDelaySecondsExclusive() {
+        return maximumDelaySecondsExclusive;
+    }
+
+    public static CreditAgency fromAgencyNumber(int agencyNumber) {
+        return Arrays.stream(values())
+                .filter(agency -> agency.agencyNumber == agencyNumber)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported credit agency number: " + agencyNumber));
+    }
+}

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -34,7 +34,7 @@ public class CrecustService {
             DateTimeFormatter.ofPattern("ddMMuuuu").withResolverStyle(ResolverStyle.STRICT);
     private static final int CREDIT_AGENCY_COUNT = 5;
     private static final int REVIEW_DATE_BOUND = 20;
-    private static final long CREDIT_AGENCY_TIMEOUT_SECONDS = 6;
+    private static final long CREDIT_AGENCY_REPLY_WINDOW_SECONDS = 3;
     private static final List<String> VALID_TITLES = List.of(
             "Professor", "Mr", "Mrs", "Miss", "Ms", "Dr", "Drs", "Lord", "Sir", "Lady", ""
     );
@@ -151,6 +151,7 @@ public class CrecustService {
             futures.add(creditAgencyService.requestCreditScore(request, agencyNumber));
         }
 
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CREDIT_AGENCY_REPLY_WINDOW_SECONDS);
         int totalScore = 0;
         int returnedScores = 0;
         boolean interrupted = false;
@@ -160,7 +161,13 @@ public class CrecustService {
                 continue;
             }
             try {
-                Optional<Integer> maybeScore = future.get(CREDIT_AGENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    future.cancel(true);
+                    continue;
+                }
+
+                Optional<Integer> maybeScore = future.get(remainingNanos, TimeUnit.NANOSECONDS);
                 if (maybeScore.isPresent()) {
                     totalScore += maybeScore.get();
                     returnedScores++;

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -177,8 +177,13 @@ public class CrecustService {
         int totalScore = 0;
         int returnedScores = 0;
         for (CompletableFuture<Optional<Integer>> future : futures) {
-            if (!future.isDone() || future.isCompletedExceptionally() || future.isCancelled()) {
-                future.cancel(true);
+            if (future.isCompletedExceptionally() || future.isCancelled()) {
+                continue;
+            }
+            // cancel(true) returns false if the future already completed
+            // normally, in which case we still harvest its score; this avoids
+            // dropping replies that completed between isDone() and cancel().
+            if (!future.isDone() && future.cancel(true)) {
                 continue;
             }
             try {

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -151,44 +151,48 @@ public class CrecustService {
             futures.add(creditAgencyService.requestCreditScore(request, agencyNumber));
         }
 
-        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CREDIT_AGENCY_REPLY_WINDOW_SECONDS);
+        // Single overall reply window across all agencies, mirroring the COBOL
+        // DELAY FOR SECONDS(3) + FETCH ANY NOSUSPEND flow. Wait for whichever
+        // agencies finish before the deadline and ignore the rest, so one slow
+        // agency cannot starve replies that already completed.
+        try {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                    .get(CREDIT_AGENCY_REPLY_WINDOW_SECONDS, TimeUnit.SECONDS);
+        } catch (TimeoutException ignored) {
+            // Some agencies did not reply within the overall window; fall through
+            // and harvest whichever did complete.
+        } catch (ExecutionException | CompletionException ignored) {
+            // Ignore individual credit-agency failures and average only successful replies.
+        } catch (InterruptedException exception) {
+            // Treat interruption as an immediate overall credit-check failure
+            // so we do not persist a customer based on partially collected
+            // scores while cancellation is being signaled.
+            Thread.currentThread().interrupt();
+            for (CompletableFuture<Optional<Integer>> future : futures) {
+                future.cancel(true);
+            }
+            return null;
+        }
+
         int totalScore = 0;
         int returnedScores = 0;
-        boolean interrupted = false;
         for (CompletableFuture<Optional<Integer>> future : futures) {
-            if (interrupted) {
+            if (!future.isDone() || future.isCompletedExceptionally() || future.isCancelled()) {
                 future.cancel(true);
                 continue;
             }
             try {
-                long remainingNanos = deadlineNanos - System.nanoTime();
-                if (remainingNanos <= 0) {
-                    future.cancel(true);
-                    continue;
-                }
-
-                Optional<Integer> maybeScore = future.get(remainingNanos, TimeUnit.NANOSECONDS);
+                Optional<Integer> maybeScore = future.getNow(Optional.empty());
                 if (maybeScore.isPresent()) {
                     totalScore += maybeScore.get();
                     returnedScores++;
                 }
-            } catch (TimeoutException exception) {
-                // Bound the wait per agency so a hung credit-agency call cannot
-                // block the request indefinitely; treat as fail code G fodder.
-                future.cancel(true);
-            } catch (ExecutionException | CompletionException exception) {
-                // Ignore individual credit-agency failures and average only successful replies.
-            } catch (InterruptedException exception) {
-                // Treat interruption as an immediate overall credit-check failure
-                // so we do not persist a customer based on partially collected
-                // scores while cancellation is being signaled.
-                Thread.currentThread().interrupt();
-                future.cancel(true);
-                interrupted = true;
+            } catch (CompletionException ignored) {
+                // Individual agency failure; average only successful replies.
             }
         }
 
-        if (interrupted || returnedScores == 0) {
+        if (returnedScores == 0) {
             return null;
         }
 

--- a/src/main/java/com/augment/cbsa/service/CreditAgencyDelayExecutor.java
+++ b/src/main/java/com/augment/cbsa/service/CreditAgencyDelayExecutor.java
@@ -1,0 +1,9 @@
+package com.augment.cbsa.service;
+
+import java.time.Duration;
+
+@FunctionalInterface
+public interface CreditAgencyDelayExecutor {
+
+    void delay(Duration duration) throws InterruptedException;
+}

--- a/src/main/java/com/augment/cbsa/service/CreditAgencyDelayGenerator.java
+++ b/src/main/java/com/augment/cbsa/service/CreditAgencyDelayGenerator.java
@@ -1,0 +1,10 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CreditAgency;
+import java.time.Duration;
+
+@FunctionalInterface
+public interface CreditAgencyDelayGenerator {
+
+    Duration nextDelay(CreditAgency agency);
+}

--- a/src/main/java/com/augment/cbsa/service/CreditAgencyScoreGenerator.java
+++ b/src/main/java/com/augment/cbsa/service/CreditAgencyScoreGenerator.java
@@ -1,0 +1,10 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CreditAgency;
+import com.augment.cbsa.domain.CrecustRequest;
+
+@FunctionalInterface
+public interface CreditAgencyScoreGenerator {
+
+    int nextCreditScore(CreditAgency agency, CrecustRequest request);
+}

--- a/src/main/java/com/augment/cbsa/service/CreditAgencyService.java
+++ b/src/main/java/com/augment/cbsa/service/CreditAgencyService.java
@@ -43,8 +43,8 @@ public class CreditAgencyService {
         }
 
         int score = scoreGenerator.nextCreditScore(agency, request);
-        if (score < 1 || score > 999) {
-            throw new IllegalArgumentException("credit agency score must be between 1 and 999");
+        if (score < 1 || score > 998) {
+            throw new IllegalArgumentException("credit agency score must be between 1 and 998");
         }
 
         return CompletableFuture.completedFuture(Optional.of(score));

--- a/src/main/java/com/augment/cbsa/service/CreditAgencyService.java
+++ b/src/main/java/com/augment/cbsa/service/CreditAgencyService.java
@@ -1,6 +1,8 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.domain.CreditAgency;
 import com.augment.cbsa.domain.CrecustRequest;
+import com.augment.cbsa.error.CbsaAbendException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -10,17 +12,41 @@ import org.springframework.stereotype.Service;
 @Service
 public class CreditAgencyService {
 
+    private final CreditAgencyDelayGenerator delayGenerator;
+    private final CreditAgencyDelayExecutor delayExecutor;
+    private final CreditAgencyScoreGenerator scoreGenerator;
+
+    public CreditAgencyService(
+            CreditAgencyDelayGenerator delayGenerator,
+            CreditAgencyDelayExecutor delayExecutor,
+            CreditAgencyScoreGenerator scoreGenerator
+    ) {
+        this.delayGenerator = Objects.requireNonNull(delayGenerator, "delayGenerator must not be null");
+        this.delayExecutor = Objects.requireNonNull(delayExecutor, "delayExecutor must not be null");
+        this.scoreGenerator = Objects.requireNonNull(scoreGenerator, "scoreGenerator must not be null");
+    }
+
     @Async("creditAgencyExecutor")
     public CompletableFuture<Optional<Integer>> requestCreditScore(CrecustRequest request, int agencyNumber) {
         Objects.requireNonNull(request, "request must not be null");
-        if (agencyNumber < 1) {
-            throw new IllegalArgumentException("agencyNumber must be positive");
+        CreditAgency agency = CreditAgency.fromAgencyNumber(agencyNumber);
+
+        try {
+            delayExecutor.delay(delayGenerator.nextDelay(agency));
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return CompletableFuture.failedFuture(new CbsaAbendException(
+                    "PLOP",
+                    "Credit agency processing was interrupted.",
+                    exception
+            ));
         }
 
-        int score = Math.floorMod(
-                Objects.hash(request.name().stripTrailing(), request.address().stripTrailing(), request.dateOfBirth(), agencyNumber),
-                900
-        ) + 100;
+        int score = scoreGenerator.nextCreditScore(agency, request);
+        if (score < 1 || score > 999) {
+            throw new IllegalArgumentException("credit agency score must be between 1 and 999");
+        }
+
         return CompletableFuture.completedFuture(Optional.of(score));
     }
 }

--- a/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
+++ b/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
@@ -1,0 +1,75 @@
+package com.augment.cbsa.web.crdtagy;
+
+import com.augment.cbsa.domain.CrecustRequest;
+import com.augment.cbsa.service.CreditAgencyService;
+import com.augment.cbsa.web.crecust.dto.CrecustCommareaResponseDto;
+import com.augment.cbsa.web.crecust.dto.CrecustRequestDto;
+import com.augment.cbsa.web.crecust.dto.CrecustResponseDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/crdtagy")
+public class CrdtagyController {
+
+    private final CreditAgencyService creditAgencyService;
+
+    public CrdtagyController(CreditAgencyService creditAgencyService) {
+        this.creditAgencyService = Objects.requireNonNull(creditAgencyService, "creditAgencyService must not be null");
+    }
+
+    @PostMapping("/{agencyNumber}")
+    public CrecustResponseDto process(
+            @PathVariable @Min(1) @Max(5) int agencyNumber,
+            @Valid @RequestBody CrecustRequestDto requestDto
+    ) {
+        var commarea = requestDto.creCust();
+        int creditScore = awaitCreditScore(new CrecustRequest(
+                commarea.commName(),
+                commarea.commAddress(),
+                commarea.commDateOfBirth()
+        ), agencyNumber);
+
+        return new CrecustResponseDto(new CrecustCommareaResponseDto(
+                defaultString(commarea.commEyecatcher()),
+                commarea.commKey(),
+                commarea.commName(),
+                commarea.commAddress(),
+                commarea.commDateOfBirth(),
+                creditScore,
+                defaultInt(commarea.commCsReviewDate()),
+                defaultString(commarea.commSuccess()),
+                defaultString(commarea.commFailCode())
+        ));
+    }
+
+    private int awaitCreditScore(CrecustRequest request, int agencyNumber) {
+        try {
+            return creditAgencyService.requestCreditScore(request, agencyNumber).join().orElse(0);
+        } catch (CompletionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IllegalStateException("Credit agency processing failed.", cause);
+        }
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
+    }
+
+    private int defaultInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
+++ b/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
@@ -1,6 +1,7 @@
 package com.augment.cbsa.web.crdtagy;
 
 import com.augment.cbsa.domain.CrecustRequest;
+import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.service.CreditAgencyService;
 import com.augment.cbsa.web.crecust.dto.CrecustCommareaResponseDto;
 import com.augment.cbsa.web.crecust.dto.CrecustRequestDto;
@@ -9,7 +10,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RequestMapping("/api/v1/crdtagy")
 public class CrdtagyController {
+
+    private static final long CREDIT_AGENCY_TIMEOUT_SECONDS = 5;
 
     private final CreditAgencyService creditAgencyService;
 
@@ -54,14 +61,23 @@ public class CrdtagyController {
     }
 
     private int awaitCreditScore(CrecustRequest request, int agencyNumber) {
+        CompletableFuture<java.util.Optional<Integer>> future =
+                creditAgencyService.requestCreditScore(request, agencyNumber);
         try {
-            return creditAgencyService.requestCreditScore(request, agencyNumber).join().orElse(0);
-        } catch (CompletionException exception) {
+            return future.get(CREDIT_AGENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS).orElse(0);
+        } catch (TimeoutException exception) {
+            future.cancel(true);
+            throw new CbsaAbendException("PLOP", "Credit agency processing timed out.", exception);
+        } catch (ExecutionException | CompletionException exception) {
             Throwable cause = exception.getCause();
             if (cause instanceof RuntimeException runtimeException) {
                 throw runtimeException;
             }
             throw new IllegalStateException("Credit agency processing failed.", cause);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+            throw new CbsaAbendException("PLOP", "Credit agency processing was interrupted.", exception);
         }
     }
 

--- a/src/test/java/com/augment/cbsa/service/CreditAgencyServiceIntegrationTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreditAgencyServiceIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CrecustRequest;
+import com.augment.cbsa.support.AbstractCockroachIntegrationTest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class CreditAgencyServiceIntegrationTest extends AbstractCockroachIntegrationTest {
+
+    @Autowired
+    private CreditAgencyService creditAgencyService;
+
+    @MockBean
+    private CreditAgencyDelayGenerator creditAgencyDelayGenerator;
+
+    @MockBean
+    private CreditAgencyDelayExecutor creditAgencyDelayExecutor;
+
+    @MockBean
+    private CreditAgencyScoreGenerator creditAgencyScoreGenerator;
+
+    @Test
+    void returnsAgencySpecificScoresWithinSpringContext() throws Exception {
+        when(creditAgencyDelayGenerator.nextDelay(any())).thenReturn(Duration.ZERO);
+        when(creditAgencyScoreGenerator.nextCreditScore(any(), any())).thenAnswer(invocation -> 400 + invocation.getArgument(0, com.augment.cbsa.domain.CreditAgency.class).agencyNumber());
+
+        CrecustRequest request = new CrecustRequest("Dr Alice Example", "1 Main Street", 10_01_2000);
+
+        assertThat(creditAgencyService.requestCreditScore(request, 1).get(1, TimeUnit.SECONDS)).contains(401);
+        assertThat(creditAgencyService.requestCreditScore(request, 5).get(1, TimeUnit.SECONDS)).contains(405);
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/CreditAgencyServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreditAgencyServiceUnitTest.java
@@ -47,10 +47,10 @@ class CreditAgencyServiceUnitTest {
 
     @Test
     void rejectsScoresOutsideCobolRange() {
-        CreditAgencyService service = new CreditAgencyService(agency -> Duration.ZERO, duration -> { }, (agency, request) -> 1_000);
+        CreditAgencyService service = new CreditAgencyService(agency -> Duration.ZERO, duration -> { }, (agency, request) -> 999);
 
         assertThatThrownBy(() -> service.requestCreditScore(REQUEST, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("between 1 and 999");
+                .hasMessageContaining("between 1 and 998");
     }
 }

--- a/src/test/java/com/augment/cbsa/service/CreditAgencyServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreditAgencyServiceUnitTest.java
@@ -1,0 +1,56 @@
+package com.augment.cbsa.service;
+
+import com.augment.cbsa.domain.CrecustRequest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CreditAgencyServiceUnitTest {
+
+    private static final CrecustRequest REQUEST = new CrecustRequest("Dr Alice Example", "1 Main Street", 10_01_2000);
+
+    @Test
+    void mapsEveryAgencyThroughInjectedDelayAndScoreComponents() {
+        List<Duration> observedDelays = new ArrayList<>();
+        CreditAgencyService service = new CreditAgencyService(
+                agency -> Duration.ofMillis(agency.agencyNumber() * 10L),
+                observedDelays::add,
+                (agency, request) -> 300 + agency.agencyNumber()
+        );
+
+        for (int agencyNumber = 1; agencyNumber <= 5; agencyNumber++) {
+            assertThat(service.requestCreditScore(REQUEST, agencyNumber).join())
+                    .contains(300 + agencyNumber);
+        }
+
+        assertThat(observedDelays).containsExactly(
+                Duration.ofMillis(10),
+                Duration.ofMillis(20),
+                Duration.ofMillis(30),
+                Duration.ofMillis(40),
+                Duration.ofMillis(50)
+        );
+    }
+
+    @Test
+    void rejectsUnknownAgencyNumbers() {
+        CreditAgencyService service = new CreditAgencyService(agency -> Duration.ZERO, duration -> { }, (agency, request) -> 500);
+
+        assertThatThrownBy(() -> service.requestCreditScore(REQUEST, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported credit agency number");
+    }
+
+    @Test
+    void rejectsScoresOutsideCobolRange() {
+        CreditAgencyService service = new CreditAgencyService(agency -> Duration.ZERO, duration -> { }, (agency, request) -> 1_000);
+
+        assertThatThrownBy(() -> service.requestCreditScore(REQUEST, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("between 1 and 999");
+    }
+}

--- a/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
@@ -1,0 +1,106 @@
+package com.augment.cbsa.web.crdtagy;
+
+import com.augment.cbsa.domain.CrecustRequest;
+import com.augment.cbsa.error.CbsaAbendException;
+import com.augment.cbsa.error.CbsaExceptionHandler;
+import com.augment.cbsa.service.CreditAgencyService;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CrdtagyController.class)
+@Import(CbsaExceptionHandler.class)
+class CrdtagyControllerWebMvcTest {
+
+    private static final CrecustRequest REQUEST = new CrecustRequest("Dr Alice Example", "1 Main Street", 10_01_2000);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreditAgencyService creditAgencyService;
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5})
+    void returnsSuccessfulResponseForEveryAgencyRoute(int agencyNumber) throws Exception {
+        when(creditAgencyService.requestCreditScore(eq(REQUEST), eq(agencyNumber)))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(450 + agencyNumber)));
+
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", agencyNumber)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestJson()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.CreCust.CommEyecatcher").value("CUST"))
+                .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreCust.CommCreditScore").value(450 + agencyNumber));
+    }
+
+    @Test
+    void rejectsOutOfRangeAgencyNumbers() throws Exception {
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 6)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestJson()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void requestValidationFailuresRemainProblemDetails() throws Exception {
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 1)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"CreCust":{"CommKey":{"CommSortcode":1000000,"CommNumber":0},"CommName":"Dr Alice Example","CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void redactsAbendExceptionMessageFromAsyncFailures() throws Exception {
+        when(creditAgencyService.requestCreditScore(eq(REQUEST), eq(3)))
+                .thenReturn(CompletableFuture.failedFuture(new CbsaAbendException("PLOP", "sensitive delay failure")));
+
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 3)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestJson()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.detail").value("Service abend"))
+                .andExpect(jsonPath("$.abendCode").value("PLOP"))
+                .andExpect(content().string(not(containsString("sensitive delay failure"))));
+    }
+
+    private String requestJson() {
+        return """
+                {
+                  "CreCust": {
+                    "CommEyecatcher": "CUST",
+                    "CommKey": {"CommSortcode": 987654, "CommNumber": 42},
+                    "CommName": "Dr Alice Example",
+                    "CommAddress": "1 Main Street",
+                    "CommDateOfBirth": 10012000,
+                    "CommCreditScore": 0,
+                    "CommCsReviewDate": 0,
+                    "CommSuccess": " ",
+                    "CommFailCode": " "
+                  }
+                }
+                """;
+    }
+}


### PR DESCRIPTION
**Source program**
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CRDTAGY1.cbl
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CRDTAGY2.cbl
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CRDTAGY3.cbl
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CRDTAGY4.cbl
- https://github.com/augment-solutions/cics-banking-sample-application-cbsa/blob/main/src/base/cobol_src/CRDTAGY5.cbl

**Mapped REST endpoints**
- `POST /api/v1/crdtagy/{agencyNumber}` where `agencyNumber` is `1`..`5`

**Notable decisions**
- Modeled the five COBOL programs as a shared CreditAgency enum/registry plus one async CreditAgencyService, avoiding five copy-paste service classes.
- Reused the existing CreCust DTO envelope because the CRDTAGY container layout matches the customer commarea that CRECUST already sends to the async child programs.
- Kept the credit-agency delay/score generators injectable for deterministic tests while using @Async("creditAgencyExecutor") with the existing virtual-thread executor in production.
- Mirrored the COBOL COMPUTE/integer-receiver behavior with exclusive upper bounds (nextLong(1, 3) effective delay range and nextInt(1, 999) effective score range), rather than the looser prose comments in the COBOL headers.
- Tightened CrecustService to a single 3-second overall reply window so the parent orchestration matches the COBOL DELAY FOR SECONDS(3) + FETCH ANY NOSUSPEND flow more closely.
- No Flyway migration was needed because CRDTAGY is a pure async simulation with no new persistence tables.

**Test coverage**
- Unit: `CreditAgencyServiceUnitTest`
- @SpringBootTest: `CreditAgencyServiceIntegrationTest`
- MockMvc: `CrdtagyControllerWebMvcTest`
- Regression coverage: `CrecustServiceUnitTest`, `CrecustServiceIntegrationTest`
