### PR TITLE
fix(sortcode): typed config + zero-padded sortcodes

### DIFF
--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -160,6 +160,21 @@ Never persist both forms.
 - When reading a fixed-width numeric identifier back from a numeric persistence
   column, always zero-pad it back to its COBOL width before returning it to the
   domain or wire contract.
+- Use `[0-9]{6}` (explicit ASCII range) rather than `\d{6}` in
+  `@Pattern(regexp = ...)` annotations. Java's `\d` can match non-ASCII Unicode
+  digits when `UNICODE_CHARACTER_CLASS` is enabled in the validator runtime,
+  which would let unexpected values pass and then fail downstream string
+  comparisons or JDBC lookups.
+- Enforce the same six-digit ASCII invariant on the read side too: domain
+  records that carry a sortcode (e.g. `AccountDetails`, `CustomerDetails`)
+  validate `[0-9]{6}` in their canonical constructor so controllers do not
+  need to re-pad or re-validate before serialising. Any non-conforming value
+  read from the database fails loudly at the repository→domain boundary.
+- YAML coerces unquoted values that look numeric (`012345`) into integers,
+  which silently drops leading zeros and then fails `[0-9]{6}` startup
+  validation. Always quote zero-padded fixed-width identifiers in
+  `application.yaml` (and any environment-variable defaults), e.g.
+  `cbsa.sortcode: "987654"`.
 - Issues #11 and #17 are the empirical source for this rule: parsing sortcodes
   with `Integer.parseInt(...)` caused runtime 500s and could silently lose
   leading zeros.

--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -147,7 +147,24 @@ Never persist both forms.
   failure path, and one invariant assertion (e.g. balance non-negative
   after operation).
 
-## 10. PR / commit conventions
+## 10. Configuration: typed properties + startup validation (sortcode and friends)
+
+- Every COBOL-shaped fixed-width identifier configured via Spring must be bound
+  through a dedicated `@ConfigurationProperties` record with
+  `jakarta.validation` annotations and `@Validated`, so malformed values fail
+  application startup instead of surfacing later as request-time 500s.
+- Keep zero-padded fixed-width identifiers as `String` end-to-end in domain,
+  services, controllers, DTOs, and tests. Convert to `int` only at the jOOQ
+  persistence boundary when a column truly requires it, and only after a regex
+  constraint has guaranteed the value is exactly six digits.
+- When reading a fixed-width numeric identifier back from a numeric persistence
+  column, always zero-pad it back to its COBOL width before returning it to the
+  domain or wire contract.
+- Issues #11 and #17 are the empirical source for this rule: parsing sortcodes
+  with `Integer.parseInt(...)` caused runtime 500s and could silently lose
+  leading zeros.
+
+## 11. PR / commit conventions
 
 - One COBOL program per branch and per PR. Branch name: `migrate/<PROGRAM>`.
 - Commit subject: `feat(<program>): translate <PROGRAM> to Java`.
@@ -156,7 +173,7 @@ Never persist both forms.
 - The Reviewer posts exactly `LGTM` to approve, or a comment starting with
   `BLOCK:` listing each blocking issue on its own line.
 
-## 11. Out of scope
+## 12. Out of scope
 
 `BNK1*`, `BNKMENU` (BMS terminal handlers), `BANKDATA` (seed loader; replaced
 by Flyway), and `ABNDPROC` (replaced by `@ControllerAdvice`) are dropped and

--- a/src/main/java/com/augment/cbsa/CbsaApplication.java
+++ b/src/main/java/com/augment/cbsa/CbsaApplication.java
@@ -1,13 +1,16 @@
 package com.augment.cbsa;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.service.RandomCustomerNumberGenerator;
 import java.util.Random;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableConfigurationProperties(CbsaProperties.class)
 public class CbsaApplication {
 
     @Bean

--- a/src/main/java/com/augment/cbsa/config/CbsaProperties.java
+++ b/src/main/java/com/augment/cbsa/config/CbsaProperties.java
@@ -9,7 +9,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "cbsa")
 public record CbsaProperties(
         @NotNull
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String sortcode
 ) {
 }

--- a/src/main/java/com/augment/cbsa/config/CbsaProperties.java
+++ b/src/main/java/com/augment/cbsa/config/CbsaProperties.java
@@ -1,0 +1,15 @@
+package com.augment.cbsa.config;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "cbsa")
+public record CbsaProperties(
+        @NotNull
+        @Pattern(regexp = "\\d{6}")
+        String sortcode
+) {
+}

--- a/src/main/java/com/augment/cbsa/domain/AccountDetails.java
+++ b/src/main/java/com/augment/cbsa/domain/AccountDetails.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public record AccountDetails(
         String sortcode,
@@ -19,6 +20,8 @@ public record AccountDetails(
         BigDecimal actualBalance
 ) {
 
+    private static final Pattern SORTCODE_PATTERN = Pattern.compile("[0-9]{6}");
+
     public AccountDetails {
         Objects.requireNonNull(sortcode, "sortcode must not be null");
         Objects.requireNonNull(accountType, "accountType must not be null");
@@ -28,8 +31,8 @@ public record AccountDetails(
         Objects.requireNonNull(availableBalance, "availableBalance must not be null");
         Objects.requireNonNull(actualBalance, "actualBalance must not be null");
 
-        if (sortcode.length() != 6) {
-            throw new IllegalArgumentException("sortcode must be exactly 6 characters");
+        if (!SORTCODE_PATTERN.matcher(sortcode).matches()) {
+            throw new IllegalArgumentException("sortcode must be exactly 6 ASCII digits");
         }
 
         if (accountType.length() > 8) {

--- a/src/main/java/com/augment/cbsa/domain/CustomerDetails.java
+++ b/src/main/java/com/augment/cbsa/domain/CustomerDetails.java
@@ -2,6 +2,7 @@ package com.augment.cbsa.domain;
 
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public record CustomerDetails(
         String sortcode,
@@ -13,11 +14,17 @@ public record CustomerDetails(
         LocalDate csReviewDate
 ) {
 
+    private static final Pattern SORTCODE_PATTERN = Pattern.compile("[0-9]{6}");
+
     public CustomerDetails {
         Objects.requireNonNull(sortcode, "sortcode must not be null");
         Objects.requireNonNull(name, "name must not be null");
         Objects.requireNonNull(address, "address must not be null");
         Objects.requireNonNull(dateOfBirth, "dateOfBirth must not be null");
+
+        if (!SORTCODE_PATTERN.matcher(sortcode).matches()) {
+            throw new IllegalArgumentException("sortcode must be exactly 6 ASCII digits");
+        }
 
         if (creditScore < 0 || creditScore > 999) {
             throw new IllegalArgumentException("creditScore must be between 0 and 999");

--- a/src/main/java/com/augment/cbsa/service/CreaccService.java
+++ b/src/main/java/com/augment/cbsa/service/CreaccService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.CreaccCommand;
 import com.augment.cbsa.domain.CreaccRequest;
 import com.augment.cbsa.domain.CreaccResult;
@@ -16,7 +17,6 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,13 +34,13 @@ public class CreaccService {
             CreaccRepository creaccRepository,
             InqcustService inqcustService,
             InqacccuService inqacccuService,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             Clock clock
     ) {
         this.creaccRepository = Objects.requireNonNull(creaccRepository, "creaccRepository must not be null");
         this.inqcustService = Objects.requireNonNull(inqcustService, "inqcustService must not be null");
         this.inqacccuService = Objects.requireNonNull(inqacccuService, "inqacccuService must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.CrecustCommand;
 import com.augment.cbsa.domain.CrecustRequest;
 import com.augment.cbsa.domain.CrecustResult;
@@ -24,7 +25,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -48,13 +48,13 @@ public class CrecustService {
     public CrecustService(
             CrecustRepository crecustRepository,
             CreditAgencyService creditAgencyService,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             Clock clock,
             @Qualifier("crecustReviewRandom") Random reviewDateRandom
     ) {
         this.crecustRepository = Objects.requireNonNull(crecustRepository, "crecustRepository must not be null");
         this.creditAgencyService = Objects.requireNonNull(creditAgencyService, "creditAgencyService must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
         this.reviewDateRandom = Objects.requireNonNull(reviewDateRandom, "reviewDateRandom must not be null");
     }

--- a/src/main/java/com/augment/cbsa/service/DbcrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/DbcrfunService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.DbcrfunOrigin;
 import com.augment.cbsa.domain.DbcrfunRequest;
@@ -18,7 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -37,13 +37,13 @@ public class DbcrfunService {
             DbcrfunRepository dbcrfunRepository,
             DSLContext dsl,
             TransactionTemplate transactionTemplate,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             Clock clock
     ) {
         this.dbcrfunRepository = Objects.requireNonNull(dbcrfunRepository, "dbcrfunRepository must not be null");
         this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
         this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 

--- a/src/main/java/com/augment/cbsa/service/DelaccService.java
+++ b/src/main/java/com/augment/cbsa/service/DelaccService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.DelaccRequest;
 import com.augment.cbsa.domain.DelaccResult;
@@ -17,7 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -39,13 +39,13 @@ public class DelaccService {
             DelaccRepository delaccRepository,
             DSLContext dsl,
             TransactionTemplate transactionTemplate,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             Clock clock
     ) {
         this.delaccRepository = Objects.requireNonNull(delaccRepository, "delaccRepository must not be null");
         this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
         this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 

--- a/src/main/java/com/augment/cbsa/service/InqaccService.java
+++ b/src/main/java/com/augment/cbsa/service/InqaccService.java
@@ -1,12 +1,12 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.InqaccRequest;
 import com.augment.cbsa.domain.InqaccResult;
 import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.repository.AccountRepository;
 import java.util.Objects;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,9 +21,9 @@ public class InqaccService {
     private final AccountRepository accountRepository;
     private final String sortcode;
 
-    public InqaccService(AccountRepository accountRepository, @Value("${cbsa.sortcode}") String sortcode) {
+    public InqaccService(AccountRepository accountRepository, CbsaProperties cbsaProperties) {
         this.accountRepository = accountRepository;
-        this.sortcode = sortcode;
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
     }
 
     public InqaccResult inquire(InqaccRequest request) {

--- a/src/main/java/com/augment/cbsa/service/InqacccuService.java
+++ b/src/main/java/com/augment/cbsa/service/InqacccuService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.InqacccuRequest;
 import com.augment.cbsa.domain.InqacccuResult;
@@ -10,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,11 +32,11 @@ public class InqacccuService {
     public InqacccuService(
             AccountRepository accountRepository,
             InqcustService inqcustService,
-            @Value("${cbsa.sortcode}") String sortcode
+            CbsaProperties cbsaProperties
     ) {
         this.accountRepository = accountRepository;
         this.inqcustService = inqcustService;
-        this.sortcode = sortcode;
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
     }
 
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true)

--- a/src/main/java/com/augment/cbsa/service/InqcustService.java
+++ b/src/main/java/com/augment/cbsa/service/InqcustService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.CustomerDetails;
 import com.augment.cbsa.domain.InqcustRequest;
 import com.augment.cbsa.domain.InqcustResult;
@@ -8,7 +9,6 @@ import com.augment.cbsa.repository.CustomerRepository;
 import java.util.Objects;
 import java.util.Optional;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,11 +28,11 @@ public class InqcustService {
 
     public InqcustService(
             CustomerRepository customerRepository,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             RandomCustomerNumberGenerator randomCustomerNumberGenerator
     ) {
         this.customerRepository = customerRepository;
-        this.sortcode = sortcode;
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.randomCustomerNumberGenerator = randomCustomerNumberGenerator;
     }
 

--- a/src/main/java/com/augment/cbsa/service/UpdaccService.java
+++ b/src/main/java/com/augment/cbsa/service/UpdaccService.java
@@ -1,10 +1,10 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.UpdaccRequest;
 import com.augment.cbsa.domain.UpdaccResult;
 import com.augment.cbsa.repository.UpdaccRepository;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,9 +13,9 @@ public class UpdaccService {
     private final UpdaccRepository updaccRepository;
     private final String sortcode;
 
-    public UpdaccService(UpdaccRepository updaccRepository, @Value("${cbsa.sortcode}") String sortcode) {
+    public UpdaccService(UpdaccRepository updaccRepository, CbsaProperties cbsaProperties) {
         this.updaccRepository = Objects.requireNonNull(updaccRepository, "updaccRepository must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
     }
 
     public UpdaccResult update(UpdaccRequest request) {

--- a/src/main/java/com/augment/cbsa/service/UpdcustService.java
+++ b/src/main/java/com/augment/cbsa/service/UpdcustService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.UpdcustRequest;
 import com.augment.cbsa.domain.UpdcustResult;
 import com.augment.cbsa.repository.UpdcustRepository;
@@ -12,7 +13,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,9 +26,9 @@ public class UpdcustService {
     private final String sortcode;
     private final Clock clock;
 
-    public UpdcustService(UpdcustRepository updcustRepository, @Value("${cbsa.sortcode}") String sortcode, Clock clock) {
+    public UpdcustService(UpdcustRepository updcustRepository, CbsaProperties cbsaProperties, Clock clock) {
         this.updcustRepository = Objects.requireNonNull(updcustRepository, "updcustRepository must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 

--- a/src/main/java/com/augment/cbsa/service/XfrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/XfrfunService.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.service;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.XfrfunRequest;
 import com.augment.cbsa.domain.XfrfunResult;
@@ -19,7 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -45,13 +45,13 @@ public class XfrfunService {
             XfrfunRepository xfrfunRepository,
             DSLContext dsl,
             TransactionTemplate transactionTemplate,
-            @Value("${cbsa.sortcode}") String sortcode,
+            CbsaProperties cbsaProperties,
             Clock clock
     ) {
         this.xfrfunRepository = Objects.requireNonNull(xfrfunRepository, "xfrfunRepository must not be null");
         this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
         this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 

--- a/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
@@ -94,7 +94,7 @@ public class CreaccController {
         return new CreaccResponseDto(new CreaccCommareaResponseDto(
                 EYE_CATCHER,
                 account.customerNumber(),
-                new CreaccKeyDto(Integer.parseInt(account.sortcode()), account.accountNumber()),
+                new CreaccKeyDto(account.sortcode(), account.accountNumber()),
                 account.accountType(),
                 account.interestRate(),
                 toCobolDate(account.opened()),

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 public record CreaccKeyDto(
         @JsonProperty("CommSortcode")
         @NotNull
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String commSortcode,
 
         @JsonProperty("CommNumber")

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.Objects;
 
 public record CreaccKeyDto(
         @JsonProperty("CommSortcode")
         @NotNull
-        @Min(0)
-        @Max(999_999)
-        Integer commSortcode,
+        @Pattern(regexp = "\\d{6}")
+        String commSortcode,
 
         @JsonProperty("CommNumber")
         @NotNull

--- a/src/main/java/com/augment/cbsa/web/crecust/CrecustController.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/CrecustController.java
@@ -83,7 +83,7 @@ public class CrecustController {
         CustomerDetails customer = Objects.requireNonNull(result.customer(), "Successful response requires a customer");
         return new CrecustResponseDto(new CrecustCommareaResponseDto(
                 EYE_CATCHER,
-                new CrecustKeyDto(Integer.parseInt(customer.sortcode()), customer.customerNumber()),
+                new CrecustKeyDto(customer.sortcode(), customer.customerNumber()),
                 customer.name(),
                 customer.address(),
                 toCobolDate(customer.dateOfBirth()),

--- a/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.Objects;
 
 public record CrecustKeyDto(
         @JsonProperty("CommSortcode")
         @NotNull
-        @Min(0)
-        @Max(999_999)
-        Integer commSortcode,
+        @Pattern(regexp = "\\d{6}")
+        String commSortcode,
 
         @JsonProperty("CommNumber")
         @NotNull

--- a/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 public record CrecustKeyDto(
         @JsonProperty("CommSortcode")
         @NotNull
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String commSortcode,
 
         @JsonProperty("CommNumber")

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/DbcrfunController.java
@@ -86,7 +86,7 @@ public class DbcrfunController {
         return new DbcrfunResponseDto(new DbcrfunCommareaResponseDto(
                 commarea.commAccno(),
                 request.amount(),
-                Integer.parseInt(account.sortcode()),
+                account.sortcode(),
                 account.availableBalance(),
                 account.actualBalance(),
                 toDto(request.origin()),

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
@@ -26,9 +26,8 @@ public record DbcrfunCommareaRequestDto(
         BigDecimal commAmt,
 
         @JsonProperty("mSortC")
-        @Min(0)
-        @Max(999_999)
-        Integer mSortC,
+        @Pattern(regexp = "\\d{6}")
+        String mSortC,
 
         @JsonProperty("CommAvBal")
         @Digits(integer = 10, fraction = 2)

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaRequestDto.java
@@ -26,7 +26,7 @@ public record DbcrfunCommareaRequestDto(
         BigDecimal commAmt,
 
         @JsonProperty("mSortC")
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String mSortC,
 
         @JsonProperty("CommAvBal")

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunCommareaResponseDto.java
@@ -11,7 +11,7 @@ public record DbcrfunCommareaResponseDto(
         BigDecimal commAmt,
 
         @JsonProperty("mSortC")
-        int mSortC,
+        String mSortC,
 
         @JsonProperty("CommAvBal")
         BigDecimal commAvBal,

--- a/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
@@ -85,7 +85,7 @@ public class InqaccController {
         return new InqaccResponseDto(
                 EYE_CATCHER,
                 account.customerNumber(),
-                Integer.parseInt(account.sortcode()),
+                account.sortcode(),
                 account.accountNumber(),
                 account.accountType(),
                 account.interestRate(),

--- a/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/dto/InqaccResponseDto.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 public record InqaccResponseDto(
         String eye,
         long customerNumber,
-        int sortcode,
+        String sortcode,
         long accountNumber,
         String accountType,
         BigDecimal interestRate,

--- a/src/main/java/com/augment/cbsa/web/updcust/UpdcustController.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/UpdcustController.java
@@ -89,7 +89,7 @@ public class UpdcustController {
         CustomerDetails customer = Objects.requireNonNull(result.customer(), "Successful response requires a customer");
         return new UpdcustResponseDto(new UpdcustCommareaResponseDto(
                 EYE_CATCHER,
-                String.format(Locale.ROOT, "%06d", Integer.parseInt(customer.sortcode())),
+                customer.sortcode(),
                 String.format(Locale.ROOT, "%010d", customer.customerNumber()),
                 customer.name(),
                 customer.address(),

--- a/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/XfrfunController.java
@@ -1,5 +1,6 @@
 package com.augment.cbsa.web.xfrfun;
 
+import com.augment.cbsa.config.CbsaProperties;
 import com.augment.cbsa.domain.XfrfunRequest;
 import com.augment.cbsa.domain.XfrfunResult;
 import com.augment.cbsa.service.XfrfunService;
@@ -9,7 +10,6 @@ import com.augment.cbsa.web.xfrfun.dto.XfrfunRequestDto;
 import com.augment.cbsa.web.xfrfun.dto.XfrfunResponseDto;
 import jakarta.validation.Valid;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +27,9 @@ public class XfrfunController {
     private final XfrfunService xfrfunService;
     private final String sortcode;
 
-    public XfrfunController(XfrfunService xfrfunService, @Value("${cbsa.sortcode}") String sortcode) {
+    public XfrfunController(XfrfunService xfrfunService, CbsaProperties cbsaProperties) {
         this.xfrfunService = Objects.requireNonNull(xfrfunService, "xfrfunService must not be null");
-        this.sortcode = Objects.requireNonNull(sortcode, "sortcode must not be null");
+        this.sortcode = Objects.requireNonNull(cbsaProperties, "cbsaProperties must not be null").sortcode();
     }
 
     @PostMapping
@@ -48,9 +48,9 @@ public class XfrfunController {
 
         return ResponseEntity.ok(new XfrfunResponseDto(new XfrfunCommareaResponseDto(
                 commarea.commFaccno(),
-                Integer.parseInt(sortcode),
+                sortcode,
                 commarea.commTaccno(),
-                Integer.parseInt(sortcode),
+                sortcode,
                 serviceRequest.amount(),
                 result.fromAvailableBalance(),
                 result.fromActualBalance(),

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
@@ -19,7 +19,7 @@ public record XfrfunCommareaRequestDto(
 
         @JsonProperty("CommFscode")
         @NotNull
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String commFscode,
 
         @JsonProperty("CommTaccno")
@@ -30,7 +30,7 @@ public record XfrfunCommareaRequestDto(
 
         @JsonProperty("CommTscode")
         @NotNull
-        @Pattern(regexp = "\\d{6}")
+        @Pattern(regexp = "[0-9]{6}")
         String commTscode,
 
         @JsonProperty("CommAmt")

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaRequestDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.math.BigDecimal;
 
 public record XfrfunCommareaRequestDto(
@@ -18,9 +19,8 @@ public record XfrfunCommareaRequestDto(
 
         @JsonProperty("CommFscode")
         @NotNull
-        @Min(0)
-        @Max(999_999)
-        Integer commFscode,
+        @Pattern(regexp = "\\d{6}")
+        String commFscode,
 
         @JsonProperty("CommTaccno")
         @NotNull
@@ -30,9 +30,8 @@ public record XfrfunCommareaRequestDto(
 
         @JsonProperty("CommTscode")
         @NotNull
-        @Min(0)
-        @Max(999_999)
-        Integer commTscode,
+        @Pattern(regexp = "\\d{6}")
+        String commTscode,
 
         @JsonProperty("CommAmt")
         @NotNull

--- a/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaResponseDto.java
+++ b/src/main/java/com/augment/cbsa/web/xfrfun/dto/XfrfunCommareaResponseDto.java
@@ -8,13 +8,13 @@ public record XfrfunCommareaResponseDto(
         long commFaccno,
 
         @JsonProperty("CommFscode")
-        int commFscode,
+        String commFscode,
 
         @JsonProperty("CommTaccno")
         long commTaccno,
 
         @JsonProperty("CommTscode")
-        int commTscode,
+        String commTscode,
 
         @JsonProperty("CommAmt")
         BigDecimal commAmt,

--- a/src/test/java/com/augment/cbsa/config/CbsaPropertiesValidationTest.java
+++ b/src/test/java/com/augment/cbsa/config/CbsaPropertiesValidationTest.java
@@ -1,0 +1,44 @@
+package com.augment.cbsa.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CbsaPropertiesValidationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    ValidationAutoConfiguration.class
+            ))
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void rejectsSortcodesThatAreNotExactlySixDigitsAtStartup() {
+        contextRunner.withPropertyValues("cbsa.sortcode=12345").run(context -> {
+            assertThat(context).hasFailed();
+            Throwable startupFailure = context.getStartupFailure();
+            assertThat(startupFailure).hasRootCauseInstanceOf(org.springframework.boot.context.properties.bind.validation.BindValidationException.class);
+            assertThat(mostSpecificCause(startupFailure).getMessage()).contains("sortcode");
+        });
+    }
+
+    private Throwable mostSpecificCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(CbsaProperties.class)
+    static class TestConfig {
+    }
+}

--- a/src/test/java/com/augment/cbsa/service/CreaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CreaccServiceUnitTest.java
@@ -40,7 +40,13 @@ class CreaccServiceUnitTest {
         creaccRepository = mock(CreaccRepository.class);
         inqcustService = mock(InqcustService.class);
         inqacccuService = mock(InqacccuService.class);
-        creaccService = new CreaccService(creaccRepository, inqcustService, inqacccuService, "987654", FIXED_CLOCK);
+        creaccService = new CreaccService(
+                creaccRepository,
+                inqcustService,
+                inqacccuService,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/service/CrecustServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CrecustServiceUnitTest.java
@@ -44,7 +44,13 @@ class CrecustServiceUnitTest {
 
     @BeforeEach
     void setUp() {
-        crecustService = new CrecustService(crecustRepository, creditAgencyService, "987654", FIXED_CLOCK, reviewDateRandom);
+        crecustService = new CrecustService(
+                crecustRepository,
+                creditAgencyService,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK,
+                reviewDateRandom
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
@@ -47,7 +47,13 @@ class DbcrfunServiceUnitTest {
             TransactionCallback<DbcrfunResult> callback = invocation.getArgument(0, TransactionCallback.class);
             return callback.doInTransaction(mock(TransactionStatus.class));
         });
-        dbcrfunService = new DbcrfunService(dbcrfunRepository, dsl, transactionTemplate, "987654", FIXED_CLOCK);
+        dbcrfunService = new DbcrfunService(
+                dbcrfunRepository,
+                dsl,
+                transactionTemplate,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/service/DelaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DelaccServiceUnitTest.java
@@ -48,7 +48,13 @@ class DelaccServiceUnitTest {
             return callback.doInTransaction(new SimpleTransactionStatus());
         });
 
-        delaccService = new DelaccService(delaccRepository, dsl, transactionTemplate, "987654", FIXED_CLOCK);
+        delaccService = new DelaccService(
+                delaccRepository,
+                dsl,
+                transactionTemplate,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqaccServiceUnitTest.java
@@ -22,7 +22,7 @@ class InqaccServiceUnitTest {
     @Test
     void rejectsNullRequestWithClearMessage() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         assertThatThrownBy(() -> service.inquire(null))
                 .isInstanceOf(NullPointerException.class)
@@ -33,7 +33,7 @@ class InqaccServiceUnitTest {
     @Test
     void returnsAccountForExactAccountNumber() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
                 .thenReturn(Optional.of(account(12345678L, "ISA")));
 
@@ -48,7 +48,7 @@ class InqaccServiceUnitTest {
     @Test
     void returnsNotFoundWhenExactAccountDoesNotExist() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L)).thenReturn(Optional.empty());
 
         InqaccResult result = service.inquire(new InqaccRequest(12345678L));
@@ -63,7 +63,7 @@ class InqaccServiceUnitTest {
         // COBOL INQACC.cbl does not filter rows by account_type; blank-type
         // accounts are returned as-is.
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
                 .thenReturn(Optional.of(account(12345678L, " ")));
 
@@ -77,7 +77,7 @@ class InqaccServiceUnitTest {
     @Test
     void lastAccountModeReturnsHighestAccount() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findLastBySortcode("987654")).thenReturn(Optional.of(account(99999998L, "SAVINGS")));
 
         InqaccResult result = service.inquire(new InqaccRequest(99_999_999L));
@@ -90,7 +90,7 @@ class InqaccServiceUnitTest {
     @Test
     void lastAccountModeReturnsNotFoundWhenNoAccountsExist() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findLastBySortcode("987654")).thenReturn(Optional.empty());
 
         InqaccResult result = service.inquire(new InqaccRequest(99_999_999L));
@@ -103,7 +103,7 @@ class InqaccServiceUnitTest {
     @Test
     void wrapsExactLookupDataAccessFailuresInHracAbend() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findBySortcodeAndAccountNumber("987654", 12345678L))
                 .thenThrow(new DataAccessException("boom") {
                 });
@@ -118,7 +118,7 @@ class InqaccServiceUnitTest {
     @Test
     void wrapsLastLookupDataAccessFailuresInHncsAbend() {
         AccountRepository accountRepository = mock(AccountRepository.class);
-        InqaccService service = new InqaccService(accountRepository, "987654");
+        InqaccService service = new InqaccService(accountRepository, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(accountRepository.findLastBySortcode("987654"))
                 .thenThrow(new DataAccessException("boom") {
                 });

--- a/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqacccuServiceUnitTest.java
@@ -28,7 +28,7 @@ class InqacccuServiceUnitTest {
     void rejectsNullRequestWithClearMessage() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         assertThatThrownBy(() -> service.inquire(null))
                 .isInstanceOf(NullPointerException.class)
@@ -40,7 +40,7 @@ class InqacccuServiceUnitTest {
     void sentinelCustomerNumbersReturnNotFoundWithoutCallingDependencies() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         InqacccuResult zeroResult = service.inquire(new InqacccuRequest(0L));
         InqacccuResult lastResult = service.inquire(new InqacccuRequest(9_999_999_999L));
@@ -56,7 +56,7 @@ class InqacccuServiceUnitTest {
     void returnsNotFoundWhenLinkedCustomerInquiryFails() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(inqcustService.inquire(new InqcustRequest(10L)))
                 .thenReturn(InqcustResult.failure("1", 10L, "Customer number 10 was not found."));
 
@@ -71,7 +71,7 @@ class InqacccuServiceUnitTest {
     void returnsAccountsForExistingCustomerIncludingBlankAccountTypes() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
         AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
@@ -91,7 +91,7 @@ class InqacccuServiceUnitTest {
     void returnsOpenFailureWhenCursorCannotBeOpened() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L))
                 .thenThrow(new DataAccessException("boom") {
@@ -108,7 +108,7 @@ class InqacccuServiceUnitTest {
     void returnsFetchFailureWhenCursorIterationFails() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
         AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);
@@ -127,7 +127,7 @@ class InqacccuServiceUnitTest {
     void closeFailureOverridesEarlierFetchFailure() {
         AccountRepository accountRepository = mock(AccountRepository.class);
         InqcustService inqcustService = mock(InqcustService.class);
-        InqacccuService service = new InqacccuService(accountRepository, inqcustService, "987654");
+        InqacccuService service = new InqacccuService(accountRepository, inqcustService, new com.augment.cbsa.config.CbsaProperties("987654"));
         AccountRepository.CustomerAccountsCursor cursor = new AccountRepository.CustomerAccountsCursor(mockCursor());
         when(inqcustService.inquire(new InqcustRequest(10L))).thenReturn(InqcustResult.success(customer(10L)));
         when(accountRepository.openCustomerAccountsCursor("987654", 10L)).thenReturn(cursor);

--- a/src/test/java/com/augment/cbsa/service/InqcustServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/InqcustServiceUnitTest.java
@@ -21,7 +21,11 @@ class InqcustServiceUnitTest {
     @Test
     void rejectsNullRequestWithClearMessage() {
         CustomerRepository customerRepository = mock(CustomerRepository.class);
-        InqcustService service = new InqcustService(customerRepository, "987654", highestCustomerNumber -> 1L);
+        InqcustService service = new InqcustService(
+                customerRepository,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                highestCustomerNumber -> 1L
+        );
 
         assertThatThrownBy(() -> service.inquire(null))
                 .isInstanceOf(NullPointerException.class)
@@ -32,7 +36,11 @@ class InqcustServiceUnitTest {
     @Test
     void randomModeStopsAtRetryLimitAndReturnsRetryExhaustedFailure() {
         CustomerRepository customerRepository = mock(CustomerRepository.class);
-        InqcustService service = new InqcustService(customerRepository, "987654", highestCustomerNumber -> 1L);
+        InqcustService service = new InqcustService(
+                customerRepository,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                highestCustomerNumber -> 1L
+        );
         when(customerRepository.findLastBySortcode("987654")).thenReturn(Optional.of(customer(2L)));
         when(customerRepository.findBySortcodeAndCustomerNumber("987654", 1L)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdaccServiceUnitTest.java
@@ -19,7 +19,7 @@ class UpdaccServiceUnitTest {
     @Test
     void rejectsNullRequestWithClearMessage() {
         UpdaccRepository repository = mock(UpdaccRepository.class);
-        UpdaccService service = new UpdaccService(repository, "987654");
+        UpdaccService service = new UpdaccService(repository, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         assertThatThrownBy(() -> service.update(null))
                 .isInstanceOf(NullPointerException.class)
@@ -30,7 +30,7 @@ class UpdaccServiceUnitTest {
     @Test
     void rejectsBlankAccountTypeBeforeHittingTheRepository() {
         UpdaccRepository repository = mock(UpdaccRepository.class);
-        UpdaccService service = new UpdaccService(repository, "987654");
+        UpdaccService service = new UpdaccService(repository, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         UpdaccResult result = service.update(new UpdaccRequest(12345678L, "", new BigDecimal("2.25"), 500L));
 
@@ -43,7 +43,7 @@ class UpdaccServiceUnitTest {
     @Test
     void rejectsLeadingSpaceAccountTypeBeforeHittingTheRepository() {
         UpdaccRepository repository = mock(UpdaccRepository.class);
-        UpdaccService service = new UpdaccService(repository, "987654");
+        UpdaccService service = new UpdaccService(repository, new com.augment.cbsa.config.CbsaProperties("987654"));
 
         UpdaccResult result = service.update(new UpdaccRequest(12345678L, " ISA", new BigDecimal("2.25"), 500L));
 
@@ -55,7 +55,7 @@ class UpdaccServiceUnitTest {
     @Test
     void acceptsAnyNonBlankAccountTypeThatDoesNotStartWithSpace() {
         UpdaccRepository repository = mock(UpdaccRepository.class);
-        UpdaccService service = new UpdaccService(repository, "987654");
+        UpdaccService service = new UpdaccService(repository, new com.augment.cbsa.config.CbsaProperties("987654"));
         UpdaccRequest request = new UpdaccRequest(12345678L, "BROKER", new BigDecimal("2.25"), 500L);
         when(repository.updateAccount("987654", request)).thenReturn(UpdaccResult.success(account("BROKER")));
 

--- a/src/test/java/com/augment/cbsa/service/UpdcustServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/UpdcustServiceUnitTest.java
@@ -30,7 +30,11 @@ class UpdcustServiceUnitTest {
     @BeforeEach
     void setUp() {
         updcustRepository = mock(UpdcustRepository.class);
-        updcustService = new UpdcustService(updcustRepository, "987654", FIXED_CLOCK);
+        updcustService = new UpdcustService(
+                updcustRepository,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
@@ -49,7 +49,13 @@ class XfrfunServiceUnitTest {
             TransactionCallback<XfrfunResult> callback = invocation.getArgument(0, TransactionCallback.class);
             return callback.doInTransaction(mock(TransactionStatus.class));
         });
-        xfrfunService = new XfrfunService(xfrfunRepository, dsl, transactionTemplate, "987654", FIXED_CLOCK);
+        xfrfunService = new XfrfunService(
+                xfrfunRepository,
+                dsl,
+                transactionTemplate,
+                new com.augment.cbsa.config.CbsaProperties("987654"),
+                FIXED_CLOCK
+        );
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
@@ -48,7 +48,7 @@ class CrdtagyControllerWebMvcTest {
                         .content(requestJson()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.CreCust.CommEyecatcher").value("CUST"))
-                .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value("987654"))
                 .andExpect(jsonPath("$.CreCust.CommCreditScore").value(450 + agencyNumber));
     }
 
@@ -66,7 +66,7 @@ class CrdtagyControllerWebMvcTest {
         mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 1)
                         .contentType(APPLICATION_JSON)
                         .content("""
-                                {"CreCust":{"CommKey":{"CommSortcode":1000000,"CommNumber":0},"CommName":"Dr Alice Example","CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
+                                {"CreCust":{"CommKey":{"CommSortcode":"1000000","CommNumber":0},"CommName":"Dr Alice Example","CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
                                 """))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("Validation failed"));
@@ -91,7 +91,7 @@ class CrdtagyControllerWebMvcTest {
                 {
                   "CreCust": {
                     "CommEyecatcher": "CUST",
-                    "CommKey": {"CommSortcode": 987654, "CommNumber": 42},
+                    "CommKey": {"CommSortcode": "987654", "CommNumber": 42},
                     "CommName": "Dr Alice Example",
                     "CommAddress": "1 Main Street",
                     "CommDateOfBirth": 10012000,

--- a/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerTest.java
@@ -57,7 +57,7 @@ class CreaccControllerTest extends AbstractCockroachIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.CreAcc.CommEyecatcher").value("ACCT"))
                 .andExpect(jsonPath("$.CreAcc.CommCustno").value(10))
-                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value("987654"))
                 .andExpect(jsonPath("$.CreAcc.CommKey.CommNumber").value(1))
                 .andExpect(jsonPath("$.CreAcc.CommOpened").value(Integer.parseInt(today.format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy")))))
                 .andExpect(jsonPath("$.CreAcc.CommNextStmtDt").value(Integer.parseInt(today.plusDays(30).format(java.time.format.DateTimeFormatter.ofPattern("ddMMyyyy")))));
@@ -131,7 +131,7 @@ class CreaccControllerTest extends AbstractCockroachIntegrationTest {
                   "CreAcc": {
                     "CommEyecatcher": "ACCT",
                     "CommCustno": %d,
-                    "CommKey": {"CommSortcode": 0, "CommNumber": 0},
+                    "CommKey": {"CommSortcode": "000000", "CommNumber": 0},
                     "CommAccType": "%s",
                     "CommIntRt": 1.50,
                     "CommOpened": 0,

--- a/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/creacc/CreaccControllerWebMvcTest.java
@@ -44,7 +44,7 @@ class CreaccControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.CreAcc.CommEyecatcher").value("ACCT"))
                 .andExpect(jsonPath("$.CreAcc.CommCustno").value(10))
-                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreAcc.CommKey.CommSortcode").value("987654"))
                 .andExpect(jsonPath("$.CreAcc.CommKey.CommNumber").value(1));
     }
 
@@ -96,7 +96,7 @@ class CreaccControllerWebMvcTest {
                   "CreAcc": {
                     "CommEyecatcher": "ACCT",
                     "CommCustno": %d,
-                    "CommKey": {"CommSortcode": 0, "CommNumber": 0},
+                    "CommKey": {"CommSortcode": "000000", "CommNumber": 0},
                     "CommAccType": "%s",
                     "CommIntRt": 1.50,
                     "CommOpened": 0,

--- a/src/test/java/com/augment/cbsa/web/crecust/CrecustControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crecust/CrecustControllerWebMvcTest.java
@@ -53,7 +53,7 @@ class CrecustControllerWebMvcTest {
                         .content(requestJson("Dr Alice Example", "1 Main Street", 10_01_2000)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.CreCust.CommEyecatcher").value("CUST"))
-                .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value(987654))
+                .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value("987654"))
                 .andExpect(jsonPath("$.CreCust.CommKey.CommNumber").value(1))
                 .andExpect(jsonPath("$.CreCust.CommCreditScore").value(430));
     }
@@ -90,7 +90,7 @@ class CrecustControllerWebMvcTest {
         mockMvc.perform(post("/api/v1/crecust/insert")
                         .contentType(APPLICATION_JSON)
                         .content("""
-                                {"CreCust":{"CommKey":{"CommSortcode":1000000,"CommNumber":0},"CommName":"Dr Alice Example","CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
+                                {"CreCust":{"CommKey":{"CommSortcode":"1000000","CommNumber":0},"CommName":"Dr Alice Example","CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
                                 """))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("Validation failed"));
@@ -115,7 +115,7 @@ class CrecustControllerWebMvcTest {
                 {
                   "CreCust": {
                     "CommEyecatcher": "CUST",
-                    "CommKey": {"CommSortcode": 0, "CommNumber": 0},
+                    "CommKey": {"CommSortcode": "000000", "CommNumber": 0},
                     "CommName": "%s",
                     "CommAddress": "%s",
                     "CommDateOfBirth": %d,

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerTest.java
@@ -51,7 +51,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
         mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("-25.00", 496)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
-                .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
+                .andExpect(jsonPath("$.PAYDBCR.mSortC").value("987654"))
                 .andExpect(jsonPath("$.PAYDBCR.CommAvBal").value(475.00))
                 .andExpect(jsonPath("$.PAYDBCR.CommActBal").value(475.00))
                 .andExpect(jsonPath("$.PAYDBCR.CommSuccess").value("Y"))
@@ -132,7 +132,7 @@ class DbcrfunControllerTest extends AbstractCockroachIntegrationTest {
                   "PAYDBCR": {
                     "CommAccno": "12345678",
                     "CommAmt": %s,
-                    "mSortC": 0,
+                    "mSortC": "000000",
                     "CommAvBal": 0,
                     "CommActBal": 0,
                     "CommOrigin": {

--- a/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/dbcrfun/DbcrfunControllerWebMvcTest.java
@@ -50,7 +50,7 @@ class DbcrfunControllerWebMvcTest {
         mockMvc.perform(post("/api/v1/dbcrfun").contentType(APPLICATION_JSON).content(requestJson("25.00", 496)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.PAYDBCR.CommAccno").value("12345678"))
-                .andExpect(jsonPath("$.PAYDBCR.mSortC").value(987654))
+                .andExpect(jsonPath("$.PAYDBCR.mSortC").value("987654"))
                 .andExpect(jsonPath("$.PAYDBCR.CommAvBal").value(525.00))
                 .andExpect(jsonPath("$.PAYDBCR.CommActBal").value(525.00))
                 .andExpect(jsonPath("$.PAYDBCR.CommOrigin.CommApplid").value("ABCDEFGH"))
@@ -96,7 +96,7 @@ class DbcrfunControllerWebMvcTest {
                   "PAYDBCR": {
                     "CommAccno": "12345678",
                     "CommAmt": %s,
-                    "mSortC": 0,
+                    "mSortC": "000000",
                     "CommAvBal": 0,
                     "CommActBal": 0,
                     "CommOrigin": {

--- a/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerZeroPaddedSortcodeTest.java
+++ b/src/test/java/com/augment/cbsa/web/inqacc/InqaccControllerZeroPaddedSortcodeTest.java
@@ -18,9 +18,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, properties = "cbsa.sortcode=012345")
 @AutoConfigureMockMvc
-class InqaccControllerTest extends AbstractCockroachIntegrationTest {
+class InqaccControllerZeroPaddedSortcodeTest extends AbstractCockroachIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -36,51 +36,17 @@ class InqaccControllerTest extends AbstractCockroachIntegrationTest {
     }
 
     @Test
-    void returnsAccountForSuccessfulLookup() throws Exception {
-        insertAccount(10L, 12345678L, "ISA");
+    void preservesLeadingZerosWhenReturningConfiguredSortcodes() throws Exception {
+        insertAccount(10L, 12345678L, "ISA", "012345");
 
         mockMvc.perform(get("/api/v1/inqacc/12345678"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.eye").value("ACCT"))
-                .andExpect(jsonPath("$.customerNumber").value(10))
-                .andExpect(jsonPath("$.sortcode").value("987654"))
-                .andExpect(jsonPath("$.accountNumber").value(12345678))
-                .andExpect(jsonPath("$.accountType").value("ISA"))
-                .andExpect(jsonPath("$.interestRate").value(1.50))
-                .andExpect(jsonPath("$.opened").value(2012024))
-                .andExpect(jsonPath("$.availableBalance").value(1500.25))
-                .andExpect(jsonPath("$.inquirySuccess").value("Y"));
+                .andExpect(jsonPath("$.sortcode").value("012345"));
     }
 
-    @Test
-    void returnsProblemDetailWhenAccountDoesNotExist() throws Exception {
-        mockMvc.perform(get("/api/v1/inqacc/12345678"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.title").value("Account not found"))
-                .andExpect(jsonPath("$.detail").value("Account number 12345678 was not found."))
-                .andExpect(jsonPath("$.failCode").value("1"));
-    }
-
-    @Test
-    void returnsProblemDetailWhenNoAccountsExistInLastAccountMode() throws Exception {
-        mockMvc.perform(get("/api/v1/inqacc/99999999"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.title").value("Account not found"))
-                .andExpect(jsonPath("$.detail").value("No accounts exist."))
-                .andExpect(jsonPath("$.failCode").value("1"));
-    }
-
-    @Test
-    void rejectsAccountNumbersOutsideTheCopybookRange() throws Exception {
-        mockMvc.perform(get("/api/v1/inqacc/100000000"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.title").value("Validation failed"));
-    }
-
-    private void insertAccount(long customerNumber, long accountNumber, String accountType) {
+    private void insertAccount(long customerNumber, long accountNumber, String accountType, String sortcode) {
         dsl.insertInto(CUSTOMER)
-                .set(CUSTOMER.SORTCODE, "987654")
+                .set(CUSTOMER.SORTCODE, sortcode)
                 .set(CUSTOMER.CUSTOMER_NUMBER, customerNumber)
                 .set(CUSTOMER.NAME, "Example Customer %d".formatted(customerNumber))
                 .set(CUSTOMER.ADDRESS, "%d Example Road".formatted(customerNumber))
@@ -90,7 +56,7 @@ class InqaccControllerTest extends AbstractCockroachIntegrationTest {
                 .execute();
 
         dsl.insertInto(ACCOUNT)
-                .set(ACCOUNT.SORTCODE, "987654")
+                .set(ACCOUNT.SORTCODE, sortcode)
                 .set(ACCOUNT.ACCOUNT_NUMBER, accountNumber)
                 .set(ACCOUNT.CUSTOMER_NUMBER, customerNumber)
                 .set(ACCOUNT.ACCOUNT_TYPE, accountType)

--- a/src/test/java/com/augment/cbsa/web/xfrfun/XfrfunControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/xfrfun/XfrfunControllerWebMvcTest.java
@@ -6,6 +6,7 @@ import com.augment.cbsa.error.CbsaExceptionHandler;
 import com.augment.cbsa.service.XfrfunService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -22,7 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(XfrfunController.class)
 @Import(CbsaExceptionHandler.class)
-@TestPropertySource(properties = "cbsa.sortcode=987654")
+@EnableConfigurationProperties(com.augment.cbsa.config.CbsaProperties.class)
+@TestPropertySource(properties = "cbsa.sortcode=012345")
 class XfrfunControllerWebMvcTest {
 
     @Autowired
@@ -44,8 +46,9 @@ class XfrfunControllerWebMvcTest {
         mockMvc.perform(post("/api/v1/xfrfun").contentType(APPLICATION_JSON).content(requestJson("25.00")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.XFRFUN.CommFaccno").value(12345678))
-                .andExpect(jsonPath("$.XFRFUN.CommFscode").value(987654))
+                .andExpect(jsonPath("$.XFRFUN.CommFscode").value("012345"))
                 .andExpect(jsonPath("$.XFRFUN.CommTaccno").value(87654321))
+                .andExpect(jsonPath("$.XFRFUN.CommTscode").value("012345"))
                 .andExpect(jsonPath("$.XFRFUN.CommTavbal").value(175.00))
                 .andExpect(jsonPath("$.XFRFUN.CommSuccess").value("Y"));
     }
@@ -84,9 +87,9 @@ class XfrfunControllerWebMvcTest {
                 {
                   "XFRFUN": {
                     "CommFaccno": 12345678,
-                    "CommFscode": 111111,
+                    "CommFscode": "111111",
                     "CommTaccno": 87654321,
-                    "CommTscode": 222222,
+                    "CommTscode": "222222",
                     "CommAmt": %s
                   }
                 }


### PR DESCRIPTION
## Summary
- bind cbsa.sortcode through validated CbsaProperties instead of scattered @Value / Integer.parseInt(...) usage
- preserve sortcodes as six-character zero-padded strings across controllers, services, DTOs, domain responses, and tests
- add startup-validation and zero-padding regression coverage, and document the rule in docs/translation-rules.md

## Validation
- CBSA_TESTS_USE_LOCAL_COCKROACH=true COCKROACH_URL=jdbc:postgresql://localhost:26257/cbsa?sslmode=disable COCKROACH_USER=root COCKROACH_PASSWORD='' ./mvnw -B verify

Closes #11
Closes #17
Partial progress on #5
Partial progress on #6
