### PR TITLE
fix(proctran): standardise audit-trail write failures on CbsaAbendException(HWPT)

### DIFF
--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -188,7 +188,51 @@ Never persist both forms.
 - The Reviewer posts exactly `LGTM` to approve, or a comment starting with
   `BLOCK:` listing each blocking issue on its own line.
 
-## 12. Out of scope
+## 12. PROCTRAN audit-trail write failures
+
+Every program in this codebase writes a `PROCTRAN` row as part of the
+mutating transaction it performs (account/customer create, update, delete,
+debit/credit, transfer). A failure to write `PROCTRAN` is **not** a
+domain-level failure of the operation; it is a system abend that must be
+escalated to operations.
+
+- A non-retryable `DataAccessException` thrown by a `PROCTRAN` insert MUST
+  be wrapped in `CbsaAbendException(PROCTRAN_ABEND_CODE, ...)` where
+  `PROCTRAN_ABEND_CODE = "HWPT"`. The `@ControllerAdvice` then surfaces
+  this as a 500 abend, which is the right classification for an
+  audit-trail outage.
+- Do not map `PROCTRAN` insert failures to a domain "fail code" (e.g.
+  CRECUST `"1"`, UPDCUST `"3"`). Doing so makes an audit-write outage
+  indistinguishable from a real data-mutation failure and silently
+  downgrades a 500 to a 200-with-fail-code.
+- Always re-throw `SQLSTATE 40001` (serialization failures) so the
+  surrounding `CrdbRetry` wrapper can retry the whole transaction.
+  Wrap *only* the non-retryable branch:
+  ```java
+  } catch (DataAccessException exception) {
+      if (isSerializationFailure(exception)) {
+          throw exception;
+      }
+      throw new CbsaAbendException(PROCTRAN_ABEND_CODE,
+              "<PROGRAM> failed to write the audit trail.", exception);
+  }
+  ```
+- Use the constant name `PROCTRAN_ABEND_CODE` (not `ABEND_CODE`,
+  `WPCD`, or any program-specific spelling) so the intent of the catch
+  block is obvious in code review.
+- The wrap may live in either the repository or the service layer,
+  whichever owns the `PROCTRAN` insert call site:
+  - Repositories that own their own transaction (e.g. `CreaccRepository`,
+    `CrecustRepository`, `UpdcustRepository`, `DbcrfunRepository`) wrap
+    the `PROCTRAN` `try/catch` directly inside the transactional method.
+  - Services that drive a `TransactionTemplate` themselves (e.g.
+    `DelaccService`, `DelcusService`, `XfrfunService`) wrap the call from
+    the service. The repository method itself stays a plain insert.
+- Issues #12 and #19 are the empirical source for this rule: PROCTRAN
+  failures in CRECUST / UPDCUST were originally returning fail codes
+  `"1"` / `"3"`, hiding audit-trail outages behind a 200 OK response.
+
+## 13. Out of scope
 
 `BNK1*`, `BNKMENU` (BMS terminal handlers), `BANKDATA` (seed loader; replaced
 by Flyway), and `ABNDPROC` (replaced by `@ControllerAdvice`) are dropped and

--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -223,11 +223,21 @@ escalated to operations.
 - The wrap may live in either the repository or the service layer,
   whichever owns the `PROCTRAN` insert call site:
   - Repositories that own their own transaction (e.g. `CreaccRepository`,
-    `CrecustRepository`, `UpdcustRepository`, `DbcrfunRepository`) wrap
-    the `PROCTRAN` `try/catch` directly inside the transactional method.
+    `CrecustRepository`, `UpdcustRepository`) wrap the `PROCTRAN`
+    `try/catch` directly inside the transactional method.
   - Services that drive a `TransactionTemplate` themselves (e.g.
-    `DelaccService`, `DelcusService`, `XfrfunService`) wrap the call from
-    the service. The repository method itself stays a plain insert.
+    `DbcrfunService`, `DelaccService`, `DelcusService`, `XfrfunService`)
+    own the transaction; the wrap may live either in the service (e.g.
+    `DelaccService`, `DelcusService`, `XfrfunService`) or in the
+    repository's `insertProcTran(...)` method called from inside that
+    template (e.g. `DbcrfunRepository`).
+- `PROCTRAN_ABEND_CODE` is for PROCTRAN insert failures only. Reserve a
+  separate `RETRY_EXHAUSTED_ABEND_CODE = "XRTY"` for the outer
+  `catch (DataAccessException)` around `CrdbRetry.run(...)` so a
+  serialization-retry exhaustion does not get reported as `HWPT`. Any
+  other `DataAccessException` that escapes `CrdbRetry.run` (in practice
+  none, since inner catches handle each call site) should be re-thrown
+  and surfaced via the global `Exception` handler as `UNEX`.
 - Issues #12 and #19 are the empirical source for this rule: PROCTRAN
   failures in CRECUST / UPDCUST were originally returning fail codes
   `"1"` / `"3"`, hiding audit-trail outages behind a 200 OK response.

--- a/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
@@ -3,7 +3,9 @@ package com.augment.cbsa.repository;
 import com.augment.cbsa.domain.CrecustCommand;
 import com.augment.cbsa.domain.CrecustResult;
 import com.augment.cbsa.domain.CustomerDetails;
+import com.augment.cbsa.error.CbsaAbendException;
 import java.math.BigDecimal;
+import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import org.jooq.DSLContext;
@@ -22,6 +24,9 @@ public class CrecustRepository {
     private static final String GLOBAL_CONTROL_ID = "GLOBAL";
     private static final DateTimeFormatter PROCTRAN_DOB_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     private static final long MAX_CUSTOMER_NUMBER = 9_999_999_999L;
+    // Standard abend code for failures to write the PROCTRAN audit trail.
+    // See Section 12 of docs/translation-rules.md.
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
 
     private final DSLContext dsl;
 
@@ -37,8 +42,8 @@ public class CrecustRepository {
         } catch (RollbackFailureException exception) {
             return exception.result();
         } catch (DataAccessException exception) {
-            throw new com.augment.cbsa.error.CbsaAbendException(
-                    "HWPT",
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
                     "CRECUST failed to persist the customer data.",
                     exception
             );
@@ -130,8 +135,14 @@ public class CrecustRepository {
                     .set(PROCTRAN.AMOUNT, new BigDecimal("0.00"))
                     .execute();
         } catch (DataAccessException exception) {
-            throw new com.augment.cbsa.error.CbsaAbendException(
-                    "HWPT",
+            // Re-throw serialization failures so CrdbRetry can retry the
+            // transaction; only non-retryable PROCTRAN write failures should
+            // surface as a system abend.
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
                     "CRECUST failed to write the audit trail.",
                     exception
             );
@@ -149,6 +160,17 @@ public class CrecustRepository {
                 + String.format("%010d", customer.customerNumber())
                 + String.format("%-14.14s", customer.name())
                 + customer.dateOfBirth().format(PROCTRAN_DOB_FORMATTER);
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private static final class RollbackFailureException extends RuntimeException {

--- a/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
@@ -68,6 +68,11 @@ public class CrecustRepository {
                     .forUpdate()
                     .fetchOne();
         } catch (DataAccessException exception) {
+            // Re-throw serialization failures so CrdbRetry can retry the
+            // transaction; otherwise translate to a domain fail code.
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw rollbackFailure("3", "Unable to reserve the next customer number.");
         }
 
@@ -113,6 +118,9 @@ public class CrecustRepository {
                     .set(CUSTOMER.CS_REVIEW_DATE, customer.csReviewDate())
                     .execute();
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw rollbackFailure("1", "Unable to create the customer record.");
         }
 
@@ -126,6 +134,9 @@ public class CrecustRepository {
                     .and(CONTROL.CUSTOMER_LAST.eq(baselineLast))
                     .execute();
         } catch (DataAccessException exception) {
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
             throw rollbackFailure("4", "Unable to update the customer control record.");
         }
         if (controlUpdated != 1) {

--- a/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
@@ -27,6 +27,9 @@ public class CrecustRepository {
     // Standard abend code for failures to write the PROCTRAN audit trail.
     // See Section 12 of docs/translation-rules.md.
     private static final String PROCTRAN_ABEND_CODE = "HWPT";
+    // Distinct code for serialization-retry exhaustion escaping CrdbRetry, so
+    // operationally it is not conflated with a PROCTRAN audit-trail outage.
+    private static final String RETRY_EXHAUSTED_ABEND_CODE = "XRTY";
 
     private final DSLContext dsl;
 
@@ -42,11 +45,17 @@ public class CrecustRepository {
         } catch (RollbackFailureException exception) {
             return exception.result();
         } catch (DataAccessException exception) {
-            throw new CbsaAbendException(
-                    PROCTRAN_ABEND_CODE,
-                    "CRECUST failed to persist the customer data.",
-                    exception
-            );
+            // Inner catches translate every persistence failure into either a
+            // domain fail code or PROCTRAN_ABEND_CODE; the only path that
+            // escapes CrdbRetry.run is serialization-retry exhaustion.
+            if (isSerializationFailure(exception)) {
+                throw new CbsaAbendException(
+                        RETRY_EXHAUSTED_ABEND_CODE,
+                        "CRECUST aborted after exhausting Cockroach serialization retries.",
+                        exception
+                );
+            }
+            throw exception;
         }
     }
 

--- a/src/main/java/com/augment/cbsa/repository/DbcrfunRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/DbcrfunRepository.java
@@ -1,13 +1,16 @@
 package com.augment.cbsa.repository;
 
 import com.augment.cbsa.domain.AccountDetails;
+import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.jooq.tables.records.AccountRecord;
 import java.math.BigDecimal;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
 import java.util.Optional;
 import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
 import org.springframework.stereotype.Repository;
 
 import static com.augment.cbsa.jooq.Tables.ACCOUNT;
@@ -15,6 +18,10 @@ import static com.augment.cbsa.jooq.Tables.PROCTRAN;
 
 @Repository
 public class DbcrfunRepository {
+
+    // Standard abend code for failures to write the PROCTRAN audit trail.
+    // See Section 12 of docs/translation-rules.md.
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
 
     private final DSLContext dsl;
 
@@ -48,16 +55,41 @@ public class DbcrfunRepository {
             String description,
             BigDecimal amount
     ) {
-        dsl.insertInto(PROCTRAN)
-                .set(PROCTRAN.SORTCODE, sortcode)
-                .set(PROCTRAN.LOGICAL_DELETE, false)
-                .set(PROCTRAN.TRAN_DATE, transactionDate)
-                .set(PROCTRAN.TRAN_TIME, transactionTime)
-                .set(PROCTRAN.TRAN_REF, transactionReference)
-                .set(PROCTRAN.TRAN_TYPE, transactionType)
-                .set(PROCTRAN.DESCRIPTION, description)
-                .set(PROCTRAN.AMOUNT, amount)
-                .execute();
+        try {
+            dsl.insertInto(PROCTRAN)
+                    .set(PROCTRAN.SORTCODE, sortcode)
+                    .set(PROCTRAN.LOGICAL_DELETE, false)
+                    .set(PROCTRAN.TRAN_DATE, transactionDate)
+                    .set(PROCTRAN.TRAN_TIME, transactionTime)
+                    .set(PROCTRAN.TRAN_REF, transactionReference)
+                    .set(PROCTRAN.TRAN_TYPE, transactionType)
+                    .set(PROCTRAN.DESCRIPTION, description)
+                    .set(PROCTRAN.AMOUNT, amount)
+                    .execute();
+        } catch (DataAccessException exception) {
+            // Re-throw serialization failures so CrdbRetry (in DbcrfunService)
+            // can retry the transaction; only non-retryable PROCTRAN write
+            // failures should surface as a system abend.
+            if (isSerializationFailure(exception)) {
+                throw exception;
+            }
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
+                    "DBCRFUN failed to write the audit trail.",
+                    exception
+            );
+        }
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private AccountDetails toDomain(AccountRecord record) {

--- a/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
@@ -29,7 +29,11 @@ public class UpdcustRepository {
     // requires an audit row. Use OUC (branch update customer) and reuse the
     // existing 40-char customer description layout from OCC/ODC.
     private static final String PROCTRAN_UPDATE_CUSTOMER_TYPE = "OUC";
-    private static final String ABEND_CODE = "HWPT";
+    // Standard abend code for failures to write the PROCTRAN audit trail.
+    // Section 12 of docs/translation-rules.md requires every PROCTRAN insert
+    // failure to surface as CbsaAbendException("HWPT") rather than a domain
+    // fail code so the global handler classifies it as a 500 abend.
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
 
     private final DSLContext dsl;
 
@@ -61,7 +65,7 @@ public class UpdcustRepository {
         } catch (RollbackFailureException exception) {
             return exception.result();
         } catch (DataAccessException exception) {
-            throw new CbsaAbendException(ABEND_CODE, "UPDCUST failed to persist the customer data.", exception);
+            throw new CbsaAbendException(PROCTRAN_ABEND_CODE, "UPDCUST failed to persist the customer data.", exception);
         }
     }
 
@@ -145,7 +149,14 @@ public class UpdcustRepository {
             if (isSerializationFailure(exception)) {
                 throw exception;
             }
-            throw rollbackFailure("3", "Unable to update the customer record.");
+            // PROCTRAN audit-trail failures must surface as a system abend
+            // rather than a domain "update failed" fail code so an audit-write
+            // outage is not indistinguishable from a CUSTOMER rewrite failure.
+            throw new CbsaAbendException(
+                    PROCTRAN_ABEND_CODE,
+                    "UPDCUST failed to write the audit trail.",
+                    exception
+            );
         }
 
         return UpdcustResult.success(updatedCustomer);

--- a/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/UpdcustRepository.java
@@ -34,6 +34,9 @@ public class UpdcustRepository {
     // failure to surface as CbsaAbendException("HWPT") rather than a domain
     // fail code so the global handler classifies it as a 500 abend.
     private static final String PROCTRAN_ABEND_CODE = "HWPT";
+    // Distinct code for serialization-retry exhaustion escaping CrdbRetry, so
+    // operationally it is not conflated with a PROCTRAN audit-trail outage.
+    private static final String RETRY_EXHAUSTED_ABEND_CODE = "XRTY";
 
     private final DSLContext dsl;
 
@@ -65,7 +68,16 @@ public class UpdcustRepository {
         } catch (RollbackFailureException exception) {
             return exception.result();
         } catch (DataAccessException exception) {
-            throw new CbsaAbendException(PROCTRAN_ABEND_CODE, "UPDCUST failed to persist the customer data.", exception);
+            // Inner catches translate every persistence failure into either a
+            // domain fail code or PROCTRAN_ABEND_CODE; the only path that
+            // escapes CrdbRetry.run is serialization-retry exhaustion.
+            if (isSerializationFailure(exception)) {
+                throw new CbsaAbendException(
+                        RETRY_EXHAUSTED_ABEND_CODE,
+                        "UPDCUST aborted after exhausting Cockroach serialization retries.",
+                        exception);
+            }
+            throw exception;
         }
     }
 

--- a/src/main/java/com/augment/cbsa/service/DbcrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/DbcrfunService.java
@@ -5,10 +5,12 @@ import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.DbcrfunOrigin;
 import com.augment.cbsa.domain.DbcrfunRequest;
 import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.repository.CrdbRetry;
 import com.augment.cbsa.repository.DbcrfunRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -26,6 +28,9 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class DbcrfunService {
 
     static final int PAYMENT_FACILITY_TYPE = 496;
+    // Distinct code for serialization-retry exhaustion escaping CrdbRetry, so
+    // operationally it is not conflated with a PROCTRAN audit-trail outage.
+    private static final String RETRY_EXHAUSTED_ABEND_CODE = "XRTY";
 
     private final DbcrfunRepository dbcrfunRepository;
     private final DSLContext dsl;
@@ -58,7 +63,19 @@ public class DbcrfunService {
             );
             return Objects.requireNonNull(result, "transactionTemplate returned null result");
         } catch (DataAccessException exception) {
-            return DbcrfunResult.failure("2", "DBCRFUN failed to update the account data.");
+            // Inner persistence steps translate every retryable failure into
+            // either a domain fail code or PROCTRAN_ABEND_CODE; the only path
+            // that escapes CrdbRetry.run is serialization-retry exhaustion.
+            // Anything else is an unexpected DAE and is rethrown so the global
+            // handler can classify it as UNEX.
+            if (isSerializationFailure(exception)) {
+                throw new CbsaAbendException(
+                        RETRY_EXHAUSTED_ABEND_CODE,
+                        "DBCRFUN aborted after exhausting Cockroach serialization retries.",
+                        exception
+                );
+            }
+            throw exception;
         }
     }
 
@@ -148,5 +165,16 @@ public class DbcrfunService {
 
     private BigDecimal scale(BigDecimal value) {
         return value.setScale(2, RoundingMode.HALF_EVEN);
+    }
+
+    private static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException && "40001".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/augment/cbsa/service/XfrfunService.java
+++ b/src/main/java/com/augment/cbsa/service/XfrfunService.java
@@ -32,7 +32,9 @@ public class XfrfunService {
     private static final String SAME_ACCOUNT_ABEND_CODE = "SAME";
     private static final String FROM_ACCOUNT_ABEND_CODE = "FROM";
     private static final String TO_ACCOUNT_ABEND_CODE = "TO  ";
-    private static final String PROCTRAN_ABEND_CODE = "WPCD";
+    // Standard abend code for failures to write the PROCTRAN audit trail.
+    // See Section 12 of docs/translation-rules.md.
+    private static final String PROCTRAN_ABEND_CODE = "HWPT";
     private static final String RETRY_EXHAUSTED_ABEND_CODE = "XRTY";
 
     private final XfrfunRepository xfrfunRepository;

--- a/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/DbcrfunServiceUnitTest.java
@@ -4,8 +4,10 @@ import com.augment.cbsa.domain.AccountDetails;
 import com.augment.cbsa.domain.DbcrfunOrigin;
 import com.augment.cbsa.domain.DbcrfunRequest;
 import com.augment.cbsa.domain.DbcrfunResult;
+import com.augment.cbsa.error.CbsaAbendException;
 import com.augment.cbsa.repository.DbcrfunRepository;
 import java.math.BigDecimal;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -140,15 +142,29 @@ class DbcrfunServiceUnitTest {
     }
 
     @Test
-    void returnsGenericFailureWhenPersistenceThrowsDataAccessException() {
+    void rethrowsNonSerializationDataAccessExceptionForGlobalHandler() {
         when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenThrow(new DataAccessException("boom") {
         });
 
-        DbcrfunResult result = dbcrfunService.process(request(new BigDecimal("25.00"), 496));
+        assertThatThrownBy(() -> dbcrfunService.process(request(new BigDecimal("25.00"), 496)))
+                .isInstanceOf(DataAccessException.class)
+                .hasMessageContaining("boom");
+    }
 
-        assertThat(result.paymentSuccess()).isFalse();
-        assertThat(result.failCode()).isEqualTo("2");
-        assertThat(result.message()).isEqualTo("DBCRFUN failed to update the account data.");
+    @Test
+    void surfacesXrtyAbendWhenSerializationRetryExhausted() {
+        SQLException sqle = new SQLException("Serialization failure", "40001");
+        when(dbcrfunRepository.lockAccount("987654", 12345678L)).thenThrow(new DataAccessException("wrapped", sqle) {
+        });
+
+        assertThatThrownBy(() -> dbcrfunService.process(request(new BigDecimal("25.00"), 496)))
+                .isInstanceOf(CbsaAbendException.class)
+                .satisfies(thrown -> {
+                    CbsaAbendException abend = (CbsaAbendException) thrown;
+                    assertThat(abend.getAbendCode()).isEqualTo("XRTY");
+                    assertThat(abend.getMessage())
+                            .isEqualTo("DBCRFUN aborted after exhausting Cockroach serialization retries.");
+                });
     }
 
     private DbcrfunRequest request(BigDecimal amount, int facilityType) {

--- a/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/XfrfunServiceUnitTest.java
@@ -139,7 +139,7 @@ class XfrfunServiceUnitTest {
     }
 
     @Test
-    void wrapsAuditFailuresInWpcdAbend() {
+    void wrapsAuditFailuresInHwptAbend() {
         when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 12345678L)).thenReturn(Optional.of(account(12345678L, "100.00")));
         when(xfrfunRepository.findBySortcodeAndAccountNumberForUpdate("987654", 87654321L)).thenReturn(Optional.of(account(87654321L, "10.00")));
         when(xfrfunRepository.updateBalances("987654", 12345678L, new BigDecimal("75.00"), new BigDecimal("75.00"))).thenReturn(1);
@@ -150,7 +150,7 @@ class XfrfunServiceUnitTest {
         assertThatThrownBy(() -> xfrfunService.transfer(new XfrfunRequest(12345678L, 87654321L, new BigDecimal("25.00"))))
                 .isInstanceOf(CbsaAbendException.class)
                 .extracting(exception -> ((CbsaAbendException) exception).getAbendCode())
-                .isEqualTo("WPCD");
+                .isEqualTo("HWPT");
     }
 
     private AccountDetails account(long accountNumber, String balance) {


### PR DESCRIPTION
## Summary

PR 2 of the Polish Sweep. PROCTRAN insert failures must surface as a system abend, not a domain fail code. An audit-trail outage is an infrastructure issue and should hit the 500 path so it is alerted on / retried, not silently downgraded to a 200 OK with a fail code that is indistinguishable from a real data-mutation failure.

## Changes

- **UpdcustRepository**: PROCTRAN insert catch now throws `CbsaAbendException("HWPT")` instead of `rollbackFailure("3", ...)`; renamed `ABEND_CODE` -> `PROCTRAN_ABEND_CODE` for consistency with the rest of the codebase.
- **CrecustRepository**: extract `PROCTRAN_ABEND_CODE` constant from the inline `"HWPT"` literal; add an `isSerializationFailure` check on the inner PROCTRAN catch so SQLSTATE `40001` is rethrown to the surrounding `CrdbRetry` instead of being wrapped in HWPT and losing retry semantics.
- **DbcrfunRepository.insertProcTran**: wrap the insert in `try/catch` with the same HWPT + serialization-rethrow contract used by CRECUST/CREACC. The previous version let raw `DataAccessException` propagate.
- **XfrfunService**: change `PROCTRAN_ABEND_CODE` from `"WPCD"` to `"HWPT"` so every program in the codebase agrees on the same audit-trail abend code; rename the corresponding unit test (`wrapsAuditFailuresInWpcdAbend` -> `wrapsAuditFailuresInHwptAbend`).
- **docs/translation-rules.md**: add Section 12 codifying the rule, and renumber "Out of scope" to Section 13. The new section spells out the catch idiom, the constant name, and where the wrap should live (repository vs. service layer).

## Why HWPT and not a domain fail code?

`CrecustResult` already documents this: `H` (proctran write) is a persistence failure that maps to 5xx, not a credit/validation fail code. The same logic applies to UPDCUST: a `"3"` ("Unable to update the customer record") makes an audit-write outage indistinguishable from a real CUSTOMER rewrite failure.

## Tests

All 178 existing tests pass. `XfrfunServiceUnitTest.wrapsAuditFailuresInHwptAbend` was renamed and re-asserted against the new constant.

## Issues

Closes #12, #19, partial #14, partial #5/#6.
