### PR TITLE
fix(delcus): cross-validate body CommCustno vs path, single-space CommDelFailCd

### DIFF
--- a/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/DelcusController.java
@@ -50,7 +50,21 @@ public class DelcusController {
         // but DELCUS itself only consumes COMM-CUSTNO.
         Objects.requireNonNull(requestDto, "requestDto must not be null");
 
-        DelcusResult result = delcusService.delete(new DelcusRequest(Long.parseLong(customerNumber)));
+        long pathCustomerNumber = Long.parseLong(customerNumber);
+        // Reject body/path mismatches up front. The body's CommCustno is
+        // optional (pattern allows ""); when supplied it must agree with the
+        // path so we never silently delete the path target on a misaddressed
+        // request.
+        String bodyCustno = requestDto.delCus().commCustno();
+        if (bodyCustno != null && !bodyCustno.isEmpty()
+                && Long.parseLong(bodyCustno) != pathCustomerNumber) {
+            ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+            problemDetail.setTitle("Validation failed");
+            problemDetail.setDetail("Body CommCustno does not match path customerNumber.");
+            return ResponseEntity.badRequest().body(problemDetail);
+        }
+
+        DelcusResult result = delcusService.delete(new DelcusRequest(pathCustomerNumber));
         if (!result.deleteSuccess()) {
             return ResponseEntity.status(failureStatus(result)).body(failureBody(result));
         }
@@ -99,7 +113,10 @@ public class DelcusController {
                 customer.creditScore(),
                 toCobolDate(customer.csReviewDate()),
                 "Y",
-                ""
+                // CommDelFailCd is a fixed-width 1-char commarea slot;
+                // emit a single space on success to preserve the length-1
+                // contract for clients porting from COBOL.
+                " "
         ));
     }
 

--- a/src/test/java/com/augment/cbsa/web/delcus/DelcusControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/delcus/DelcusControllerWebMvcTest.java
@@ -50,7 +50,67 @@ class DelcusControllerWebMvcTest {
                 .andExpect(jsonPath("$.DelCus.CommEye").value("CUST"))
                 .andExpect(jsonPath("$.DelCus.CommScode").value("987654"))
                 .andExpect(jsonPath("$.DelCus.CommCustno").value("0000000001"))
-                .andExpect(jsonPath("$.DelCus.CommDelSuccess").value("Y"));
+                .andExpect(jsonPath("$.DelCus.CommDelSuccess").value("Y"))
+                .andExpect(jsonPath("$.DelCus.CommDelFailCd").value(" "));
+    }
+
+    @Test
+    void rejectsBodyCommCustnoThatMismatchesPath() throws Exception {
+        String body = """
+                {
+                  "DelCus": {
+                    "CommEye": "CUST",
+                    "CommScode": "987654",
+                    "CommCustno": "0000000002",
+                    "CommName": "",
+                    "CommAddr": "",
+                    "CommDob": 0,
+                    "CommCreditScore": 0,
+                    "CommCsReviewDate": 0,
+                    "CommDelSuccess": " ",
+                    "CommDelFailCd": " "
+                  }
+                }
+                """;
+
+        mockMvc.perform(delete("/api/v1/delcus/remove/1").contentType(APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Body CommCustno does not match path customerNumber."));
+    }
+
+    @Test
+    void acceptsMatchingBodyCommCustno() throws Exception {
+        when(delcusService.delete(new DelcusRequest(1L))).thenReturn(DelcusResult.success(new CustomerDetails(
+                "987654",
+                1L,
+                "Mr Alice Example",
+                "1 Main Street",
+                LocalDate.of(2000, 1, 10),
+                430,
+                LocalDate.of(2026, 5, 8)
+        )));
+
+        String body = """
+                {
+                  "DelCus": {
+                    "CommEye": "CUST",
+                    "CommScode": "987654",
+                    "CommCustno": "0000000001",
+                    "CommName": "",
+                    "CommAddr": "",
+                    "CommDob": 0,
+                    "CommCreditScore": 0,
+                    "CommCsReviewDate": 0,
+                    "CommDelSuccess": " ",
+                    "CommDelFailCd": " "
+                  }
+                }
+                """;
+
+        mockMvc.perform(delete("/api/v1/delcus/remove/1").contentType(APPLICATION_JSON).content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.DelCus.CommCustno").value("0000000001"));
     }
 
     @Test


### PR DESCRIPTION
Closes #23.

## What

Two follow-ups against `DelcusController`, both flagged at the round-3 cap on PR #21:

### 1. (medium) Cross-validate body `CommCustno` against path
On `DELETE /api/v1/delcus/remove/{customerNumber}`, the body's `delCus.commCustno` was previously ignored. A request whose path and body disagree would silently delete the path target. Now: when `commCustno` is supplied (the field's pattern allows the empty string for clients sending only the path), it must equal the path value (compared as `long`, so leading zeros are tolerated). Mismatch → HTTP 400 with `ProblemDetail` `title="Validation failed"`, `detail="Body CommCustno does not match path customerNumber."`.

### 2. (low) Single-space `CommDelFailCd` placeholder on success
`CommDelFailCd` is a fixed-width 1-char commarea slot. The success response now emits `" "` instead of `""` to preserve the length-1 contract for clients porting from COBOL.

## Tests

`DelcusControllerWebMvcTest` (6 tests, all green):
- `returnsSuccessfulResponseForHappyPath` — tightened to also assert `CommDelFailCd == " "`.
- `rejectsBodyCommCustnoThatMismatchesPath` — new; path `1`, body `0000000002` → 400 with the validation ProblemDetail above.
- `acceptsMatchingBodyCommCustno` — new; path `1`, body `0000000001` → 200 (also covers the leading-zero tolerance).

Local `./mvnw verify` green: 189/189.

augment review
