### PR TITLE
fix(xfrfun): require XfrfunResult success to carry a null message

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/XfrfunResult.java
+++ b/src/main/java/com/augment/cbsa/domain/XfrfunResult.java
@@ -21,7 +21,7 @@ public record XfrfunResult(
             Objects.requireNonNull(fromActualBalance, "Successful results must include the from actual balance");
             Objects.requireNonNull(toAvailableBalance, "Successful results must include the to available balance");
             Objects.requireNonNull(toActualBalance, "Successful results must include the to actual balance");
-            if (message != null && !message.isBlank()) {
+            if (message != null) {
                 throw new IllegalArgumentException("Successful results must not include a message");
             }
         } else {

--- a/src/test/java/com/augment/cbsa/domain/XfrfunResultTest.java
+++ b/src/test/java/com/augment/cbsa/domain/XfrfunResultTest.java
@@ -1,0 +1,58 @@
+package com.augment.cbsa.domain;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class XfrfunResultTest {
+
+    @Test
+    void successFactoryStoresNullMessage() {
+        XfrfunResult result = XfrfunResult.success(
+                new BigDecimal("100.00"),
+                new BigDecimal("100.00"),
+                new BigDecimal("200.00"),
+                new BigDecimal("200.00")
+        );
+
+        assertThat(result.transferSuccess()).isTrue();
+        assertThat(result.message()).isNull();
+    }
+
+    @Test
+    void successConstructorRejectsBlankMessage() {
+        assertThatThrownBy(() -> new XfrfunResult(
+                true,
+                "0",
+                new BigDecimal("100.00"),
+                new BigDecimal("100.00"),
+                new BigDecimal("200.00"),
+                new BigDecimal("200.00"),
+                " "
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Successful results must not include a message");
+    }
+
+    @Test
+    void successConstructorRejectsNonBlankMessage() {
+        assertThatThrownBy(() -> new XfrfunResult(
+                true,
+                "0",
+                new BigDecimal("100.00"),
+                new BigDecimal("100.00"),
+                new BigDecimal("200.00"),
+                new BigDecimal("200.00"),
+                "leaked"
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Successful results must not include a message");
+    }
+
+    @Test
+    void failureRejectsNullMessage() {
+        assertThatThrownBy(() -> XfrfunResult.failure("1", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("message must not be null");
+    }
+}


### PR DESCRIPTION
Closes #29.

## What

Tighten `XfrfunResult`'s success invariant on `message`.

Before: the compact constructor permitted blank/whitespace strings (`""`, `" "`, etc.) on a successful result, which could mask accidental message propagation from a failure path through `new XfrfunResult(...)` written by hand.

After: `transferSuccess == true` requires `message == null` exactly. The static `success(...)` factory still always passes `null`, and the `failure(...)` factory still requires a non-null/non-blank message, so no production callers are affected — both factories already match the tightened contract.

## Tests

New `XfrfunResultTest` (4 tests, mirroring the pattern in `InqaccResultTest` / `InqcustResultTest` / `InqacccuResultTest`):
- `successFactoryStoresNullMessage`
- `successConstructorRejectsBlankMessage` — `" "` on a successful result now throws `IllegalArgumentException("Successful results must not include a message")`
- `successConstructorRejectsNonBlankMessage` — `"leaked"` still throws (regression coverage for the existing branch)
- `failureRejectsNullMessage` — covers the existing failure factory contract

Local `./mvnw verify` green: 196/196 (XFRFUN class total: 17/17).

augment review
