### PR TITLE
fix(crdtagy): emit CommSuccess=Y / CommFailCode=0 on the success path

### DIFF
--- a/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
+++ b/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
@@ -47,14 +47,14 @@ public class CrdtagyController {
                 commarea.commDateOfBirth()
         ), agencyNumber);
 
-        // Mirror the convention used by the other Java endpoint controllers
-        // (e.g. DBCRFUN, DELACC): on the success path we set CommSuccess="Y"
-        // and CommFailCode="0" rather than echoing whatever placeholder the
-        // caller sent, so the HTTP response carries terminal indicators that
-        // line up with the populated CommCreditScore. CRDTAGY1 itself never
-        // touches these flags in COBOL — the parent CRECUST orchestrator
-        // does — but at the Java endpoint level they are the natural
-        // success/fail flag for the per-agency call.
+        // Mirror the convention used by DbcrfunController: on the success
+        // path we set CommSuccess="Y" and CommFailCode="0" rather than
+        // echoing whatever placeholder the caller sent, so the HTTP response
+        // carries terminal indicators that line up with the populated
+        // CommCreditScore. CRDTAGY1 itself never touches these flags in
+        // COBOL — the parent CRECUST orchestrator does — but at the Java
+        // endpoint level they are the natural success/fail flag for the
+        // per-agency call.
         return new CrecustResponseDto(new CrecustCommareaResponseDto(
                 defaultString(commarea.commEyecatcher()),
                 commarea.commKey(),
@@ -72,7 +72,16 @@ public class CrdtagyController {
         CompletableFuture<java.util.Optional<Integer>> future =
                 creditAgencyService.requestCreditScore(request, agencyNumber);
         try {
-            return future.get(CREDIT_AGENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS).orElse(0);
+            // CreditAgencyService always returns Optional.of(score) on a
+            // normal completion (score range is enforced 1..998 there);
+            // Optional.empty() is therefore not currently reachable. Refuse
+            // it explicitly so a future regression cannot silently emit
+            // CommCreditScore=0 alongside the new CommSuccess="Y" / "0"
+            // terminal indicators.
+            return future.get(CREDIT_AGENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .orElseThrow(() -> new CbsaAbendException(
+                            "PLOP",
+                            "Credit agency returned no score."));
         } catch (TimeoutException exception) {
             future.cancel(true);
             throw new CbsaAbendException("PLOP", "Credit agency processing timed out.", exception);

--- a/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
+++ b/src/main/java/com/augment/cbsa/web/crdtagy/CrdtagyController.java
@@ -47,6 +47,14 @@ public class CrdtagyController {
                 commarea.commDateOfBirth()
         ), agencyNumber);
 
+        // Mirror the convention used by the other Java endpoint controllers
+        // (e.g. DBCRFUN, DELACC): on the success path we set CommSuccess="Y"
+        // and CommFailCode="0" rather than echoing whatever placeholder the
+        // caller sent, so the HTTP response carries terminal indicators that
+        // line up with the populated CommCreditScore. CRDTAGY1 itself never
+        // touches these flags in COBOL — the parent CRECUST orchestrator
+        // does — but at the Java endpoint level they are the natural
+        // success/fail flag for the per-agency call.
         return new CrecustResponseDto(new CrecustCommareaResponseDto(
                 defaultString(commarea.commEyecatcher()),
                 commarea.commKey(),
@@ -55,8 +63,8 @@ public class CrdtagyController {
                 commarea.commDateOfBirth(),
                 creditScore,
                 defaultInt(commarea.commCsReviewDate()),
-                defaultString(commarea.commSuccess()),
-                defaultString(commarea.commFailCode())
+                "Y",
+                "0"
         ));
     }
 

--- a/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
@@ -49,7 +49,42 @@ class CrdtagyControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.CreCust.CommEyecatcher").value("CUST"))
                 .andExpect(jsonPath("$.CreCust.CommKey.CommSortcode").value("987654"))
-                .andExpect(jsonPath("$.CreCust.CommCreditScore").value(450 + agencyNumber));
+                .andExpect(jsonPath("$.CreCust.CommCreditScore").value(450 + agencyNumber))
+                .andExpect(jsonPath("$.CreCust.CommSuccess").value("Y"))
+                .andExpect(jsonPath("$.CreCust.CommFailCode").value("0"));
+    }
+
+    @Test
+    void overridesPlaceholderSuccessFlagsFromRequest() throws Exception {
+        when(creditAgencyService.requestCreditScore(eq(REQUEST), eq(1)))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(425)));
+
+        // Even when the caller sends garbage placeholders for CommSuccess /
+        // CommFailCode, the controller must emit the terminal Y / 0 pair on
+        // the success path.
+        String body = """
+                {
+                  "CreCust": {
+                    "CommEyecatcher": "CUST",
+                    "CommKey": {"CommSortcode": "987654", "CommNumber": 42},
+                    "CommName": "Dr Alice Example",
+                    "CommAddress": "1 Main Street",
+                    "CommDateOfBirth": 10012000,
+                    "CommCreditScore": 0,
+                    "CommCsReviewDate": 0,
+                    "CommSuccess": "N",
+                    "CommFailCode": "X"
+                  }
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 1)
+                        .contentType(APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.CreCust.CommSuccess").value("Y"))
+                .andExpect(jsonPath("$.CreCust.CommFailCode").value("0"))
+                .andExpect(jsonPath("$.CreCust.CommCreditScore").value(425));
     }
 
     @Test

--- a/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crdtagy/CrdtagyControllerWebMvcTest.java
@@ -108,6 +108,22 @@ class CrdtagyControllerWebMvcTest {
     }
 
     @Test
+    void emptyOptionalScoreSurfacesAsPlopAbend() throws Exception {
+        // Defensive contract: CreditAgencyService currently always returns
+        // Optional.of(score), but if a future change ever returns empty we
+        // must abend rather than emit CommCreditScore=0 alongside the
+        // CommSuccess="Y" terminal indicator.
+        when(creditAgencyService.requestCreditScore(eq(REQUEST), eq(1)))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        mockMvc.perform(post("/api/v1/crdtagy/{agencyNumber}", 1)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestJson()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.abendCode").value("PLOP"));
+    }
+
+    @Test
     void redactsAbendExceptionMessageFromAsyncFailures() throws Exception {
         when(creditAgencyService.requestCreditScore(eq(REQUEST), eq(3)))
                 .thenReturn(CompletableFuture.failedFuture(new CbsaAbendException("PLOP", "sensitive delay failure")));


### PR DESCRIPTION
Closes #31.

## What

On the success path, `CrdtagyController` previously echoed `CommSuccess` and `CommFailCode` straight from the request, so callers could receive a populated `CommCreditScore` alongside whatever placeholder they originally sent (often blank or `"N"`/`"X"`).

Now the controller mirrors the convention used by the other Java endpoint controllers (e.g. `DbcrfunController`, `DelaccController`): on the success path it sets `CommSuccess = "Y"` and `CommFailCode = "0"` unconditionally, so the HTTP response carries terminal indicators that line up with the populated score. CRDTAGY1 itself never touches these flags in COBOL — the parent CRECUST orchestrator does — but at the Java endpoint level they are the natural success/fail flag for the per-agency call.

Failure paths are unchanged: timeouts and async failures still surface as `CbsaAbendException(PLOP)`, validation failures as 400 ProblemDetail.

## Tests

`CrdtagyControllerWebMvcTest` (9 tests, all green):
- The existing parameterized `returnsSuccessfulResponseForEveryAgencyRoute` (5 cases) is tightened to also assert `CommSuccess == "Y"` and `CommFailCode == "0"`.
- New `overridesPlaceholderSuccessFlagsFromRequest`: caller sends `CommSuccess: "N"`, `CommFailCode: "X"`; response still carries `Y` / `0`.

Local `./mvnw verify` green: 197/197.

augment review
