### PR TITLE
fix(formatters): pin Locale.ROOT on every COBOL date formatter

### DIFF
--- a/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CreaccRepository.java
@@ -26,7 +26,8 @@ public class CreaccRepository {
     private static final String COUNTER_ABEND_CODE = "HNCS";
     private static final String PROCTRAN_ABEND_CODE = "HWPT";
     private static final long MAX_ACCOUNT_NUMBER = 99_999_999L;
-    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
 
     private final DSLContext dsl;
 

--- a/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
@@ -179,8 +179,8 @@ public class CrecustRepository {
 
     private String toDescription(CustomerDetails customer) {
         return customer.sortcode()
-                + String.format("%010d", customer.customerNumber())
-                + String.format("%-14.14s", customer.name())
+                + String.format(Locale.ROOT, "%010d", customer.customerNumber())
+                + String.format(Locale.ROOT, "%-14.14s", customer.name())
                 + customer.dateOfBirth().format(PROCTRAN_DOB_FORMATTER);
     }
 

--- a/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
+++ b/src/main/java/com/augment/cbsa/repository/CrecustRepository.java
@@ -7,6 +7,7 @@ import com.augment.cbsa.error.CbsaAbendException;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 import org.jooq.DSLContext;
 import org.jooq.Record2;
@@ -22,7 +23,8 @@ import static com.augment.cbsa.jooq.Tables.PROCTRAN;
 public class CrecustRepository {
 
     private static final String GLOBAL_CONTROL_ID = "GLOBAL";
-    private static final DateTimeFormatter PROCTRAN_DOB_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final DateTimeFormatter PROCTRAN_DOB_FORMATTER =
+            DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ROOT);
     private static final long MAX_CUSTOMER_NUMBER = 9_999_999_999L;
     // Standard abend code for failures to write the PROCTRAN audit trail.
     // See Section 12 of docs/translation-rules.md.

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -16,6 +16,7 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
@@ -31,7 +32,7 @@ import org.springframework.stereotype.Service;
 public class CrecustService {
 
     private static final DateTimeFormatter COBOL_DATE_FORMATTER =
-            DateTimeFormatter.ofPattern("ddMMuuuu").withResolverStyle(ResolverStyle.STRICT);
+            DateTimeFormatter.ofPattern("ddMMuuuu", Locale.ROOT).withResolverStyle(ResolverStyle.STRICT);
     private static final int CREDIT_AGENCY_COUNT = 5;
     private static final int REVIEW_DATE_BOUND = 20;
     private static final long CREDIT_AGENCY_REPLY_WINDOW_SECONDS = 3;

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -114,7 +114,7 @@ public class CrecustService {
     }
 
     private Optional<LocalDate> parseDateOfBirth(int cobolDate) {
-        String normalized = String.format("%08d", cobolDate);
+        String normalized = String.format(Locale.ROOT, "%08d", cobolDate);
         try {
             return Optional.of(LocalDate.parse(normalized, COBOL_DATE_FORMATTER));
         } catch (DateTimeParseException exception) {

--- a/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
@@ -11,6 +11,7 @@ import com.augment.cbsa.web.creacc.dto.CreaccResponseDto;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -27,7 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class CreaccController {
 
     private static final String EYE_CATCHER = "ACCT";
-    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
 
     private final CreaccService creaccService;
 

--- a/src/main/java/com/augment/cbsa/web/crecust/CrecustController.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/CrecustController.java
@@ -11,6 +11,7 @@ import com.augment.cbsa.web.crecust.dto.CrecustResponseDto;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -27,7 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class CrecustController {
 
     private static final String EYE_CATCHER = "CUST";
-    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
 
     private final CrecustService crecustService;
 

--- a/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacc/InqaccController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -25,7 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/inqacc")
 public class InqaccController {
 
-    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
     private static final String EYE_CATCHER = "ACCT";
 
     private final InqaccService inqaccService;

--- a/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
+++ b/src/main/java/com/augment/cbsa/web/inqacccu/InqacccuController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/inqacccu")
 public class InqacccuController {
 
-    private static final DateTimeFormatter COBOL_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private static final DateTimeFormatter COBOL_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("ddMMyyyy", Locale.ROOT);
     private static final String EYE_CATCHER = "ACCT";
 
     private final InqacccuService inqacccuService;


### PR DESCRIPTION
Closes #16.

## What

`DateTimeFormatter.ofPattern(...)` without an explicit locale uses the JVM default locale, which can emit non-ASCII digits (e.g. Eastern Arabic) under some locales. Any such output going into `PROCTRAN.DESCRIPTION` would corrupt the COBOL-shaped audit-trail text.

Audit of the codebase found seven formatters still missing a pinned locale. All seven now use `Locale.ROOT`:

**Repository:**
- `CreaccRepository.COBOL_DATE_FORMATTER` (`ddMMyyyy`)
- `CrecustRepository.PROCTRAN_DOB_FORMATTER` (`dd/MM/yyyy`)

**Service:**
- `CrecustService.COBOL_DATE_FORMATTER` (`ddMMuuuu`, used to *parse* the request DOB; locale-independent for digits but pinned for consistency)

**Controllers:**
- `InqacccuController.COBOL_DATE_FORMATTER` (`ddMMyyyy`)
- `CrecustController.COBOL_DATE_FORMATTER` (`ddMMyyyy`)
- `CreaccController.COBOL_DATE_FORMATTER` (`ddMMyyyy`)
- `InqaccController.COBOL_DATE_FORMATTER` (`ddMMyyyy`)

The formatters in `UpdcustRepository`, `DelcusRepository`, `DelaccRepository`, `DelcusController`, `DelaccController`, `UpdaccController`, `UpdcustController` already pinned `Locale.ROOT` and are unchanged.

## Tests

Behaviour is unchanged when running under an ASCII-digit locale (the CI default), so existing tests still cover the pre/post behaviour. Local `./mvnw verify` green: 198/198.

augment review
