### PR TITLE
test: cover inner PROCTRAN HWPT/XRTY catch in CRECUST and UPDCUST

### DIFF
--- a/src/test/java/com/augment/cbsa/repository/CrecustRepositoryUnitTest.java
+++ b/src/test/java/com/augment/cbsa/repository/CrecustRepositoryUnitTest.java
@@ -3,38 +3,56 @@ package com.augment.cbsa.repository;
 import com.augment.cbsa.domain.CrecustCommand;
 import com.augment.cbsa.domain.CrecustResult;
 import com.augment.cbsa.error.CbsaAbendException;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Locale;
+import org.jooq.Configuration;
 import org.jooq.DSLContext;
+import org.jooq.ExecuteContext;
+import org.jooq.ExecuteListener;
+import org.jooq.SQLDialect;
 import org.jooq.TransactionalCallable;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockDataProvider;
+import org.jooq.tools.jdbc.MockResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
 
+import static com.augment.cbsa.jooq.Tables.CONTROL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit-level coverage for the <strong>outer</strong> DataAccessException catch
- * in {@link CrecustRepository#createCustomer(CrecustCommand)}: serialization-retry
- * exhaustion escaping {@code CrdbRetry.run(...)} surfaces as {@code XRTY}, while
- * any other DAE is re-thrown so the global handler classifies it as {@code UNEX}.
+ * Unit-level coverage for the DataAccessException catches in
+ * {@link CrecustRepository#createCustomer(CrecustCommand)}:
  *
- * <p>The <strong>inner</strong> PROCTRAN-insert catch (HWPT wrapping vs SQLSTATE
- * 40001 rethrow) is intentionally <em>not</em> covered here: it sits inside the
- * {@code dsl.transactionResult(configuration -> ...)} lambda and is only
- * reachable after stubbing {@code DSL.using(Configuration)} plus the full
- * fluent CONTROL/CUSTOMER/PROCTRAN chains, which is best done as integration
- * coverage. See <a href="https://github.com/augment-solutions/cbsa-java/issues/36">#36</a>
- * for the production fix (Spring Boot's {@code DefaultExceptionTranslatorExecuteListener}
- * substitutes Spring DAEs for jOOQ DAEs, so the inner catches do not fire in
- * production today) and the integration tests that should land alongside it.
+ * <ul>
+ *   <li>The <strong>outer</strong> catch turns serialization-retry exhaustion
+ *       escaping {@code CrdbRetry.run(...)} into {@code XRTY}, and re-throws
+ *       any other DAE so the global handler classifies it as {@code UNEX}.
+ *   <li>The <strong>inner</strong> PROCTRAN-insert catch wraps non-retryable
+ *       DAEs as {@code CbsaAbendException("HWPT")} and re-throws SQLSTATE
+ *       {@code 40001} DAEs unchanged so {@code CrdbRetry} can retry. The
+ *       inner block sits inside the {@code dsl.transactionResult(configuration
+ *       -> ...)} lambda; we drive it by handing the lambda a real jOOQ
+ *       {@code Configuration} backed by a {@link MockConnection} whose
+ *       {@link MockDataProvider} succeeds for the CONTROL select / CUSTOMER
+ *       insert / CONTROL update and throws on the PROCTRAN insert.
+ * </ul>
+ *
+ * <p>See <a href="https://github.com/augment-solutions/cbsa-java/issues/36">#36</a>
+ * for the production fix (PR #37) that ensures these jOOQ DAE catches actually
+ * fire under Spring Boot's {@code DefaultExceptionTranslatorExecuteListener}.
  */
 @ExtendWith(MockitoExtension.class)
 class CrecustRepositoryUnitTest {
@@ -87,5 +105,113 @@ class CrecustRepositoryUnitTest {
         assertThatThrownBy(() -> repository.createCustomer(COMMAND))
                 .isInstanceOf(DataAccessException.class)
                 .hasMessageContaining("non-retryable");
+    }
+
+    @Test
+    void nonSerializationProctranInsertFailureWrapsAsHwptAbend() {
+        SQLException proctranSqle = new SQLException("PROCTRAN insert failed", "23505");
+        wireTransactionWithProctranFailure(proctranSqle);
+
+        assertThatThrownBy(() -> repository.createCustomer(COMMAND))
+                .isInstanceOf(CbsaAbendException.class)
+                .satisfies(thrown -> {
+                    CbsaAbendException abend = (CbsaAbendException) thrown;
+                    assertThat(abend.getAbendCode()).isEqualTo("HWPT");
+                    assertThat(abend.getMessage())
+                            .isEqualTo("CRECUST failed to write the audit trail.");
+                });
+    }
+
+    @Test
+    void serializationProctranInsertFailureSurfacesAsXrtyAfterRetryExhaustion() {
+        SQLException proctranSqle = new SQLException("Serialization failure", "40001");
+        wireTransactionWithProctranFailure(proctranSqle);
+
+        // The inner catch must re-throw the SQLSTATE 40001 DAE unchanged so
+        // CrdbRetry sees it; after MAX_ATTEMPTS retries the outer catch
+        // converts it to XRTY. We assert the terminal classification rather
+        // than count attempts to keep the test resilient to retry tuning.
+        assertThatThrownBy(() -> repository.createCustomer(COMMAND))
+                .isInstanceOf(CbsaAbendException.class)
+                .satisfies(thrown -> {
+                    CbsaAbendException abend = (CbsaAbendException) thrown;
+                    assertThat(abend.getAbendCode()).isEqualTo("XRTY");
+                    assertThat(abend.getMessage())
+                            .isEqualTo("CRECUST aborted after exhausting Cockroach serialization retries.");
+                });
+    }
+
+    /**
+     * Drive the public {@code createCustomer} through to the inner PROCTRAN
+     * catch by:
+     * <ul>
+     *   <li>building a real {@code Configuration} backed by a
+     *       {@link MockConnection} whose {@link MockDataProvider}:
+     *       <ul>
+     *         <li>returns {@code (CUSTOMER_COUNT=0, CUSTOMER_LAST=0)} for the
+     *             CONTROL {@code SELECT ... FOR UPDATE},</li>
+     *         <li>reports 1 row affected for the CUSTOMER insert and the
+     *             CONTROL update so the method reaches the PROCTRAN insert,</li>
+     *         <li>throws {@code sqle} on the PROCTRAN insert.</li>
+     *       </ul>
+     *   <li>stubbing {@code dsl.transactionResult(callable)} on the outer
+     *       mock to invoke the callable with that real configuration. The
+     *       lambda's {@code DSL.using(configuration)} call then returns a
+     *       real {@code DSLContext} that runs SQL through the provider.
+     * </ul>
+     * This avoids static mocking (subclass MockMaker can't do that) and
+     * avoids deep-stubbing every overloaded {@code .set(...)} link.
+     */
+    @SuppressWarnings("unchecked")
+    private void wireTransactionWithProctranFailure(SQLException proctranFailure) {
+        MockDataProvider provider = ctx -> {
+            String sql = ctx.sql();
+            String upper = sql == null ? "" : sql.toUpperCase(Locale.ROOT);
+            if (upper.contains("\"CONTROL\"") && upper.startsWith("SELECT")) {
+                DSLContext create = DSL.using(SQLDialect.POSTGRES);
+                org.jooq.Record2<Long, Long> row =
+                        create.newRecord(CONTROL.CUSTOMER_COUNT, CONTROL.CUSTOMER_LAST);
+                row.value1(0L);
+                row.value2(0L);
+                org.jooq.Result<org.jooq.Record2<Long, Long>> result =
+                        create.newResult(CONTROL.CUSTOMER_COUNT, CONTROL.CUSTOMER_LAST);
+                result.add(row);
+                return new MockResult[] { new MockResult(1, result) };
+            }
+            if (upper.contains("\"PROCTRAN\"")) {
+                throw proctranFailure;
+            }
+            // CUSTOMER insert and CONTROL update both report 1 row affected.
+            return new MockResult[] { new MockResult(1) };
+        };
+        Connection connection = new MockConnection(provider);
+        // Mirror what JooqAutoConfiguration installs in production:
+        // translate the underlying SQLException into a Spring DAE via
+        // SQLStateSQLExceptionTranslator (which preserves SQLSTATE 40001
+        // as TransientDataAccessException). The repository catches
+        // org.springframework.dao.DataAccessException, so without this
+        // listener the test would surface the raw jOOQ DAE.
+        SQLStateSQLExceptionTranslator translator = new SQLStateSQLExceptionTranslator();
+        ExecuteListener springTranslator = new ExecuteListener() {
+            @Override
+            public void exception(ExecuteContext ctx) {
+                SQLException sqle = ctx.sqlException();
+                if (sqle != null) {
+                    DataAccessException translated = translator.translate("jOOQ", ctx.sql(), sqle);
+                    if (translated != null) {
+                        ctx.exception(translated);
+                    }
+                }
+            }
+        };
+        Configuration realConfiguration = DSL.using(connection, SQLDialect.POSTGRES)
+                .configuration()
+                .deriveAppending(springTranslator);
+
+        when(dsl.transactionResult((TransactionalCallable<CrecustResult>) any()))
+                .thenAnswer(invocation -> {
+                    TransactionalCallable<CrecustResult> callable = invocation.getArgument(0);
+                    return callable.run(realConfiguration);
+                });
     }
 }

--- a/src/test/java/com/augment/cbsa/repository/UpdcustRepositoryUnitTest.java
+++ b/src/test/java/com/augment/cbsa/repository/UpdcustRepositoryUnitTest.java
@@ -3,38 +3,56 @@ package com.augment.cbsa.repository;
 import com.augment.cbsa.domain.UpdcustRequest;
 import com.augment.cbsa.domain.UpdcustResult;
 import com.augment.cbsa.error.CbsaAbendException;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Locale;
+import org.jooq.Configuration;
 import org.jooq.DSLContext;
+import org.jooq.ExecuteContext;
+import org.jooq.ExecuteListener;
+import org.jooq.SQLDialect;
 import org.jooq.TransactionalCallable;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockDataProvider;
+import org.jooq.tools.jdbc.MockResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
 
+import static com.augment.cbsa.jooq.Tables.CUSTOMER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit-level coverage for the <strong>outer</strong> DataAccessException catch
- * in {@link UpdcustRepository#updateCustomer}: serialization-retry exhaustion
- * escaping {@code CrdbRetry.run(...)} surfaces as {@code XRTY}, while any other
- * DAE is re-thrown so the global handler classifies it as {@code UNEX}.
+ * Unit-level coverage for the DataAccessException catches in
+ * {@link UpdcustRepository#updateCustomer}:
  *
- * <p>The <strong>inner</strong> PROCTRAN-insert catch (HWPT wrapping vs SQLSTATE
- * 40001 rethrow) is intentionally <em>not</em> covered here: it sits inside the
- * {@code dsl.transactionResult(configuration -> ...)} lambda and is only
- * reachable after stubbing {@code DSL.using(Configuration)} plus the full
- * fluent CUSTOMER/PROCTRAN chains, which is best done as integration coverage.
- * See <a href="https://github.com/augment-solutions/cbsa-java/issues/36">#36</a>
- * for the production fix (Spring Boot's {@code DefaultExceptionTranslatorExecuteListener}
- * substitutes Spring DAEs for jOOQ DAEs, so the inner catches do not fire in
- * production today) and the integration tests that should land alongside it.
+ * <ul>
+ *   <li>The <strong>outer</strong> catch turns serialization-retry exhaustion
+ *       escaping {@code CrdbRetry.run(...)} into {@code XRTY}, and re-throws
+ *       any other DAE so the global handler classifies it as {@code UNEX}.
+ *   <li>The <strong>inner</strong> PROCTRAN-insert catch wraps non-retryable
+ *       DAEs as {@code CbsaAbendException("HWPT")} and re-throws SQLSTATE
+ *       {@code 40001} DAEs unchanged so {@code CrdbRetry} can retry. The
+ *       inner block sits inside the {@code dsl.transactionResult(configuration
+ *       -> ...)} lambda; we drive it by handing the lambda a real jOOQ
+ *       {@code Configuration} backed by a {@link MockConnection} whose
+ *       {@link MockDataProvider} succeeds for the CUSTOMER select / CUSTOMER
+ *       update and throws on the PROCTRAN insert.
+ * </ul>
+ *
+ * <p>See <a href="https://github.com/augment-solutions/cbsa-java/issues/36">#36</a>
+ * for the production fix (PR #37) that ensures these jOOQ DAE catches actually
+ * fire under Spring Boot's {@code DefaultExceptionTranslatorExecuteListener}.
  */
 @ExtendWith(MockitoExtension.class)
 class UpdcustRepositoryUnitTest {
@@ -90,5 +108,120 @@ class UpdcustRepositoryUnitTest {
                 SORTCODE, REQUEST, TRANSACTION_REFERENCE, TRANSACTION_DATE, TRANSACTION_TIME))
                 .isInstanceOf(DataAccessException.class)
                 .hasMessageContaining("non-retryable");
+    }
+
+    @Test
+    void nonSerializationProctranInsertFailureWrapsAsHwptAbend() {
+        SQLException proctranSqle = new SQLException("PROCTRAN insert failed", "23505");
+        wireTransactionWithProctranFailure(proctranSqle);
+
+        assertThatThrownBy(() -> repository.updateCustomer(
+                SORTCODE, REQUEST, TRANSACTION_REFERENCE, TRANSACTION_DATE, TRANSACTION_TIME))
+                .isInstanceOf(CbsaAbendException.class)
+                .satisfies(thrown -> {
+                    CbsaAbendException abend = (CbsaAbendException) thrown;
+                    assertThat(abend.getAbendCode()).isEqualTo("HWPT");
+                    assertThat(abend.getMessage())
+                            .isEqualTo("UPDCUST failed to write the audit trail.");
+                });
+    }
+
+    @Test
+    void serializationProctranInsertFailureSurfacesAsXrtyAfterRetryExhaustion() {
+        SQLException proctranSqle = new SQLException("Serialization failure", "40001");
+        wireTransactionWithProctranFailure(proctranSqle);
+
+        // The inner catch must re-throw the SQLSTATE 40001 DAE unchanged so
+        // CrdbRetry sees it; after MAX_ATTEMPTS retries the outer catch
+        // converts it to XRTY. We assert the terminal classification rather
+        // than count attempts to keep the test resilient to retry tuning.
+        assertThatThrownBy(() -> repository.updateCustomer(
+                SORTCODE, REQUEST, TRANSACTION_REFERENCE, TRANSACTION_DATE, TRANSACTION_TIME))
+                .isInstanceOf(CbsaAbendException.class)
+                .satisfies(thrown -> {
+                    CbsaAbendException abend = (CbsaAbendException) thrown;
+                    assertThat(abend.getAbendCode()).isEqualTo("XRTY");
+                    assertThat(abend.getMessage())
+                            .isEqualTo("UPDCUST aborted after exhausting Cockroach serialization retries.");
+                });
+    }
+
+    /**
+     * Drive the public {@code updateCustomer} through to the inner PROCTRAN
+     * catch by:
+     * <ul>
+     *   <li>building a real {@code Configuration} backed by a
+     *       {@link MockConnection} whose {@link MockDataProvider}:
+     *       <ul>
+     *         <li>returns a single CUSTOMER row for the {@code SELECT ... FOR
+     *             UPDATE} so {@code fetchOne} surfaces an existing record,</li>
+     *         <li>reports 1 row affected for the CUSTOMER update so the method
+     *             reaches the PROCTRAN insert,</li>
+     *         <li>throws {@code sqle} on the PROCTRAN insert.</li>
+     *       </ul>
+     *   <li>stubbing {@code dsl.transactionResult(callable)} on the outer mock
+     *       to invoke the callable with that real configuration. The lambda's
+     *       {@code DSL.using(configuration)} call then returns a real
+     *       {@code DSLContext} that runs SQL through the provider.
+     * </ul>
+     * This avoids static mocking (subclass MockMaker can't do that) and avoids
+     * deep-stubbing every overloaded {@code .set(...)} link.
+     */
+    @SuppressWarnings("unchecked")
+    private void wireTransactionWithProctranFailure(SQLException proctranFailure) {
+        MockDataProvider provider = ctx -> {
+            String sql = ctx.sql();
+            String upper = sql == null ? "" : sql.toUpperCase(Locale.ROOT);
+            if (upper.contains("\"CUSTOMER\"") && upper.startsWith("SELECT")) {
+                DSLContext create = DSL.using(SQLDialect.POSTGRES);
+                org.jooq.Result<com.augment.cbsa.jooq.tables.records.CustomerRecord> result =
+                        create.newResult(CUSTOMER);
+                com.augment.cbsa.jooq.tables.records.CustomerRecord row =
+                        create.newRecord(CUSTOMER);
+                row.setSortcode(SORTCODE);
+                row.setCustomerNumber(REQUEST.customerNumber());
+                row.setName("Mr Old Name");
+                row.setAddress("0 Old Street");
+                row.setDateOfBirth(LocalDate.of(2000, 1, 10));
+                row.setCreditScore((short) 500);
+                row.setCsReviewDate(LocalDate.of(2026, 5, 8));
+                result.add(row);
+                return new MockResult[] { new MockResult(1, result) };
+            }
+            if (upper.contains("\"PROCTRAN\"")) {
+                throw proctranFailure;
+            }
+            // CUSTOMER update reports 1 row affected.
+            return new MockResult[] { new MockResult(1) };
+        };
+        Connection connection = new MockConnection(provider);
+        // Mirror what JooqAutoConfiguration installs in production: translate
+        // the underlying SQLException into a Spring DAE via
+        // SQLStateSQLExceptionTranslator (which preserves SQLSTATE 40001 as
+        // TransientDataAccessException). The repository catches
+        // org.springframework.dao.DataAccessException, so without this listener
+        // the test would surface the raw jOOQ DAE.
+        SQLStateSQLExceptionTranslator translator = new SQLStateSQLExceptionTranslator();
+        ExecuteListener springTranslator = new ExecuteListener() {
+            @Override
+            public void exception(ExecuteContext ctx) {
+                SQLException sqle = ctx.sqlException();
+                if (sqle != null) {
+                    DataAccessException translated = translator.translate("jOOQ", ctx.sql(), sqle);
+                    if (translated != null) {
+                        ctx.exception(translated);
+                    }
+                }
+            }
+        };
+        Configuration realConfiguration = DSL.using(connection, SQLDialect.POSTGRES)
+                .configuration()
+                .deriveAppending(springTranslator);
+
+        when(dsl.transactionResult((TransactionalCallable<UpdcustResult>) any()))
+                .thenAnswer(invocation -> {
+                    TransactionalCallable<UpdcustResult> callable = invocation.getArgument(0);
+                    return callable.run(realConfiguration);
+                });
     }
 }


### PR DESCRIPTION
Closes #35.

## What

Per-repository unit coverage for the inner PROCTRAN-insert catch in
`CrecustRepository.createCustomer(...)` and `UpdcustRepository.updateCustomer(...)`.
That catch (added in #34) wraps non-retryable PROCTRAN failures as
`CbsaAbendException("HWPT", "<PROGRAM> failed to write the audit trail.")`
and re-throws SQLSTATE `40001` failures unchanged so `CrdbRetry` can retry
them. Until now both behaviours were exercised only indirectly via
`DbcrfunRepositoryUnitTest` (same catch pattern) and integration tests
(happy-path only).

## How

The inner block sits inside `dsl.transactionResult(configuration -> ...)`
and uses `DSL.using(configuration)` to build the `txDsl`. Static-mocking
`DSL.using` is not available (subclass MockMaker doesn't support
`mockStatic`), so each test now hands the lambda a real jOOQ
`Configuration` backed by:

- `org.jooq.tools.jdbc.MockConnection` + a `MockDataProvider` that:
  - **CRECUST**: returns `(CUSTOMER_COUNT=0, CUSTOMER_LAST=0)` for the
    CONTROL `SELECT ... FOR UPDATE`, `1 row affected` for the CUSTOMER
    insert and the CONTROL update, and **throws** the seeded
    `SQLException` on the PROCTRAN insert.
  - **UPDCUST**: returns one synthesised CUSTOMER row for the
    `SELECT ... FOR UPDATE`, `1 row affected` for the CUSTOMER update,
    and throws on the PROCTRAN insert.
- A small inline `ExecuteListener` that calls Spring's
  `SQLStateSQLExceptionTranslator.translate(...)` and re-throws via
  `ctx.exception(...)`. This mirrors what
  `JooqAutoConfiguration#DefaultExceptionTranslatorExecuteListener`
  installs in production (#36 / #37) — without it the test would surface
  a raw `org.jooq.exception.DataAccessException`, which the repository's
  `catch (org.springframework.dao.DataAccessException)` does not match.
  (Spring Boot's listener class is package-private; we cannot reuse it
  directly, so the test reproduces its one-line behaviour.)

`dsl.transactionResult(callable)` on the outer mock is then stubbed to
invoke the callable with that real configuration — the lambda's
`DSL.using(configuration)` returns a real `DSLContext` whose statements
flow through the `MockDataProvider`.

## Tests

Four new tests, two per repository:

- `nonSerializationProctranInsertFailureWrapsAsHwptAbend` — non-`40001`
  `SQLException` (e.g. `23505`) → `CbsaAbendException("HWPT", "<PROG>
  failed to write the audit trail.")`.
- `serializationProctranInsertFailureSurfacesAsXrtyAfterRetryExhaustion` —
  `40001` `SQLException` → after `CrdbRetry` exhausts, the outer catch
  converts it to `CbsaAbendException("XRTY", "<PROG> aborted after
  exhausting Cockroach serialization retries.")`.

Local `./mvnw -B verify`: **202/202** (was 198/198 — +4).

## Notes

- No production code touched.
- `UpdcustRepositoryUnitTest`'s class-Javadoc previously documented why
  the inner catch was *not* unit-tested; that disclaimer is now obsolete
  and replaced with the actual coverage description, matching
  `CrecustRepositoryUnitTest`.
- The per-`SQLException` failure injection is the smallest scaffold that
  reaches the catch without a real database. Existing
  `*ServiceIntegrationTest#proctranInsertFailureSurfacesHwptAbend` tests
  (added in #37) keep the integration-level assertion that the listener
  is *actually* wired in production.

augment review
