### PR TITLE
polish(validation): replace requireNonNull with bean validation (#10, #15)

### DIFF
--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -110,6 +110,15 @@ Never persist both forms.
   of the commarea (e.g. `INQCUST-CUSTNO` → `customerNumber`).
 - Validation via `jakarta.validation` annotations; constraint violations
   yield HTTP 400 from the `@ControllerAdvice`.
+- Required fields on request-DTO records are expressed exclusively through
+  `@NotNull` (and `@NotBlank` for non-blank strings such as customer
+  name/address) on the record components, with `@Valid` on the controller
+  parameter and on every nested DTO/Key reference. Do **not** put
+  `Objects.requireNonNull(...)` checks inside the canonical constructor of
+  a request DTO: those throw `NullPointerException` during Jackson
+  deserialization, bypass `MethodArgumentNotValidException`, and surface
+  as a 500 (`UNEX`) instead of the intended 400. Issues #10 and #15 are
+  the empirical source for this rule.
 - A "not found" commarea result (e.g. `INQCUST-INQ-FAIL-CD = '1'`) maps to
   HTTP 404 with a `{ failCode, message }` body, **not** an exception.
 - Hard failures (commarea-style abend) map to HTTP 500 with a structured

--- a/src/main/java/com/augment/cbsa/service/CrecustService.java
+++ b/src/main/java/com/augment/cbsa/service/CrecustService.java
@@ -37,7 +37,7 @@ public class CrecustService {
     private static final int REVIEW_DATE_BOUND = 20;
     private static final long CREDIT_AGENCY_REPLY_WINDOW_SECONDS = 3;
     private static final List<String> VALID_TITLES = List.of(
-            "Professor", "Mr", "Mrs", "Miss", "Ms", "Dr", "Drs", "Lord", "Sir", "Lady", ""
+            "Professor", "Mr", "Mrs", "Miss", "Ms", "Dr", "Drs", "Lord", "Sir", "Lady"
     );
 
     private final CrecustRepository crecustRepository;

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccCommareaRequestDto.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
-import java.util.Objects;
 
 public record CreaccCommareaRequestDto(
         @JsonProperty("CommEyecatcher")
@@ -83,14 +82,4 @@ public record CreaccCommareaRequestDto(
         @Size(max = 1)
         String commFailCode
 ) {
-
-    public CreaccCommareaRequestDto {
-        Objects.requireNonNull(commCustno, "commCustno must not be null");
-        Objects.requireNonNull(commKey, "commKey must not be null");
-        Objects.requireNonNull(commAccType, "commAccType must not be null");
-        Objects.requireNonNull(commIntRt, "commIntRt must not be null");
-        Objects.requireNonNull(commOverdrLim, "commOverdrLim must not be null");
-        Objects.requireNonNull(commAvailBal, "commAvailBal must not be null");
-        Objects.requireNonNull(commActBal, "commActBal must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccKeyDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import java.util.Objects;
 
 public record CreaccKeyDto(
         @JsonProperty("CommSortcode")
@@ -19,9 +18,4 @@ public record CreaccKeyDto(
         @Max(99_999_999)
         Long commNumber
 ) {
-
-    public CreaccKeyDto {
-        Objects.requireNonNull(commSortcode, "commSortcode must not be null");
-        Objects.requireNonNull(commNumber, "commNumber must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/dto/CreaccRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.creacc.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record CreaccRequestDto(
         @JsonProperty("CreAcc")
@@ -11,8 +10,4 @@ public record CreaccRequestDto(
         @NotNull
         CreaccCommareaRequestDto creAcc
 ) {
-
-    public CreaccRequestDto {
-        Objects.requireNonNull(creAcc, "creAcc must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustCommareaRequestDto.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.Objects;
 
 public record CrecustCommareaRequestDto(
         @JsonProperty("CommEyecatcher")
@@ -19,7 +19,7 @@ public record CrecustCommareaRequestDto(
         CrecustKeyDto commKey,
 
         @JsonProperty("CommName")
-        @NotNull
+        @NotBlank
         @Size(max = 60)
         String commName,
 
@@ -52,11 +52,4 @@ public record CrecustCommareaRequestDto(
         @Size(max = 1)
         String commFailCode
 ) {
-
-    public CrecustCommareaRequestDto {
-        Objects.requireNonNull(commKey, "commKey must not be null");
-        Objects.requireNonNull(commName, "commName must not be null");
-        Objects.requireNonNull(commAddress, "commAddress must not be null");
-        Objects.requireNonNull(commDateOfBirth, "commDateOfBirth must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustKeyDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import java.util.Objects;
 
 public record CrecustKeyDto(
         @JsonProperty("CommSortcode")
@@ -19,9 +18,4 @@ public record CrecustKeyDto(
         @Max(9_999_999_999L)
         Long commNumber
 ) {
-
-    public CrecustKeyDto {
-        Objects.requireNonNull(commSortcode, "commSortcode must not be null");
-        Objects.requireNonNull(commNumber, "commNumber must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/crecust/dto/CrecustRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.crecust.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record CrecustRequestDto(
         @JsonProperty("CreCust")
@@ -11,8 +10,4 @@ public record CrecustRequestDto(
         @NotNull
         CrecustCommareaRequestDto creCust
 ) {
-
-    public CrecustRequestDto {
-        Objects.requireNonNull(creCust, "creCust must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/dbcrfun/dto/DbcrfunRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.dbcrfun.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record DbcrfunRequestDto(
         @JsonProperty("PAYDBCR")
@@ -11,8 +10,4 @@ public record DbcrfunRequestDto(
         @NotNull
         DbcrfunCommareaRequestDto paydbcr
 ) {
-
-    public DbcrfunRequestDto {
-        Objects.requireNonNull(paydbcr, "paydbcr must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/delcus/dto/DelcusRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.delcus.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record DelcusRequestDto(
         @JsonProperty("DelCus")
@@ -11,8 +10,4 @@ public record DelcusRequestDto(
         @NotNull
         DelcusCommareaRequestDto delCus
 ) {
-
-    public DelcusRequestDto {
-        Objects.requireNonNull(delCus, "delCus must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustCommareaRequestDto.java
@@ -3,10 +3,10 @@ package com.augment.cbsa.web.updcust.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.util.Objects;
 
 public record UpdcustCommareaRequestDto(
         @JsonProperty("CommEye")
@@ -24,12 +24,12 @@ public record UpdcustCommareaRequestDto(
         String commCustno,
 
         @JsonProperty("CommName")
-        @NotNull
+        @NotBlank
         @Size(max = 60)
         String commName,
 
         @JsonProperty("CommAddress")
-        @NotNull
+        @NotBlank
         @Size(max = 160)
         String commAddress,
 
@@ -59,14 +59,4 @@ public record UpdcustCommareaRequestDto(
         @Size(max = 1)
         String commUpdFailCd
 ) {
-
-    public UpdcustCommareaRequestDto {
-        Objects.requireNonNull(commScode, "commScode must not be null");
-        Objects.requireNonNull(commCustno, "commCustno must not be null");
-        Objects.requireNonNull(commName, "commName must not be null");
-        Objects.requireNonNull(commAddress, "commAddress must not be null");
-        Objects.requireNonNull(commDob, "commDob must not be null");
-        Objects.requireNonNull(commCreditScore, "commCreditScore must not be null");
-        Objects.requireNonNull(commCsReviewDate, "commCsReviewDate must not be null");
-    }
 }

--- a/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustRequestDto.java
+++ b/src/main/java/com/augment/cbsa/web/updcust/dto/UpdcustRequestDto.java
@@ -3,7 +3,6 @@ package com.augment.cbsa.web.updcust.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 
 public record UpdcustRequestDto(
         @JsonProperty("UpdCust")
@@ -11,8 +10,4 @@ public record UpdcustRequestDto(
         @NotNull
         UpdcustCommareaRequestDto updCust
 ) {
-
-    public UpdcustRequestDto {
-        Objects.requireNonNull(updCust, "updCust must not be null");
-    }
 }

--- a/src/test/java/com/augment/cbsa/service/CrecustServiceUnitTest.java
+++ b/src/test/java/com/augment/cbsa/service/CrecustServiceUnitTest.java
@@ -63,6 +63,15 @@ class CrecustServiceUnitTest {
     }
 
     @Test
+    void rejectsBlankCustomerNamesAtTitleValidation() {
+        CrecustResult result = crecustService.create(new CrecustRequest("   ", "1 Main Street", 1012000));
+
+        assertThat(result.creationSuccess()).isFalse();
+        assertThat(result.failCode()).isEqualTo("T");
+        verifyNoInteractions(creditAgencyService, crecustRepository, reviewDateRandom);
+    }
+
+    @Test
     void rejectsDatesEarlierThan1601() {
         CrecustResult result = crecustService.create(new CrecustRequest("Dr Example", "1 Main Street", 1011500));
 

--- a/src/test/java/com/augment/cbsa/web/crecust/CrecustControllerWebMvcTest.java
+++ b/src/test/java/com/augment/cbsa/web/crecust/CrecustControllerWebMvcTest.java
@@ -97,6 +97,28 @@ class CrecustControllerWebMvcTest {
     }
 
     @Test
+    void missingRequiredFieldReturnsBadRequest() throws Exception {
+        // CommName omitted entirely; bean validation must reject with 400 rather
+        // than letting a constructor NPE escalate to a 500 abend.
+        mockMvc.perform(post("/api/v1/crecust/insert")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"CreCust":{"CommKey":{"CommSortcode":"000000","CommNumber":0},"CommAddress":"1 Main Street","CommDateOfBirth":10012000}}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
+    void blankCommNameReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/crecust/insert")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestJson("   ", "1 Main Street", 10_01_2000)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Validation failed"));
+    }
+
+    @Test
     void redactsAbendExceptionMessageFromResponseBody() throws Exception {
         when(crecustService.create(new CrecustRequest("Dr Alice Example", "1 Main Street", 10_01_2000)))
                 .thenThrow(new CbsaAbendException("HWPT", "sensitive audit failure"));


### PR DESCRIPTION
Closes #10, closes #15.

## Why

Two related polish items:

- **#15** — `Objects.requireNonNull(...)` calls inside the canonical
  constructor of a request-DTO record are executed by Jackson during
  deserialization. When a required field is missing from the JSON body,
  Jackson sees a null component, the constructor throws
  `NullPointerException`, and `CbsaExceptionHandler#handleUnexpected`
  surfaces it as a `500` with abend code `UNEX` instead of the intended
  `400 Validation failed`. Bean-validation annotations on the
  components, combined with `@Valid` on the controller parameter and
  every nested DTO/Key reference, give us the proper 400.

- **#10** — `VALID_TITLES` in `CrecustService` contained an empty
  string, which let an empty/whitespace-only `CommName` silently bypass
  title validation. Tighten by (a) requiring `@NotBlank` at the wire
  boundary on `CrecustCommareaRequestDto.commName` and on
  `UpdcustCommareaRequestDto.commName`/`commAddress`, and (b) removing
  the empty-string entry from `VALID_TITLES` so the service-layer guard
  also rejects blank names with fail code `T`.

## What

- Drop `Objects.requireNonNull` from the canonical constructor of every
  request DTO and nested Commarea/Key DTO that participates in JSON
  deserialization: `CrecustRequestDto`, `CrecustCommareaRequestDto`,
  `CrecustKeyDto`, `CreaccRequestDto`, `CreaccCommareaRequestDto`,
  `CreaccKeyDto`, `DbcrfunRequestDto`, `UpdcustRequestDto`,
  `UpdcustCommareaRequestDto`, `DelcusRequestDto`. Existing `@NotNull`
  / `@Valid` annotations carry the contract.
- Add `@NotBlank` on `CrecustCommareaRequestDto.commName` and on
  `UpdcustCommareaRequestDto.commName`/`commAddress`.
- Remove the empty-string entry from `CrecustService.VALID_TITLES` so
  the service-layer fallback also rejects blank names.
- Document the rule in `docs/translation-rules.md §6` so future program
  translations follow the same pattern.

## Tests

- `CrecustControllerWebMvcTest`:
  - `missingRequiredFieldReturnsBadRequest` — omitting `CommName`
    yields `400` (previously would have been `500/UNEX`).
  - `blankCommNameReturnsBadRequest` — whitespace-only `CommName`
    yields `400` via `@NotBlank`.
- `CrecustServiceUnitTest`:
  - `rejectsBlankCustomerNamesAtTitleValidation` — locks in the
    service-layer rejection of blank names with fail code `T`.

`./mvnw verify`: 205/205 green locally.

augment review
