### PR TITLE
polish(creacc): drop dead transient-failure path (#14)

### DIFF
--- a/src/main/java/com/augment/cbsa/domain/CreaccResult.java
+++ b/src/main/java/com/augment/cbsa/domain/CreaccResult.java
@@ -13,7 +13,6 @@ public record CreaccResult(
     private static final Set<String> VALIDATION_FAIL_CODES = Set.of("A");
     private static final Set<String> NOT_FOUND_FAIL_CODES = Set.of("1");
     private static final Set<String> CAPACITY_FAIL_CODES = Set.of("8");
-    private static final Set<String> TRANSIENT_FAIL_CODES = Set.of("3", "5");
 
     public CreaccResult {
         Objects.requireNonNull(failCode, "failCode must not be null");
@@ -50,9 +49,5 @@ public record CreaccResult(
 
     public boolean isCapacityFailure() {
         return !creationSuccess && CAPACITY_FAIL_CODES.contains(failCode);
-    }
-
-    public boolean isTransientFailure() {
-        return !creationSuccess && TRANSIENT_FAIL_CODES.contains(failCode);
     }
 }

--- a/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
+++ b/src/main/java/com/augment/cbsa/web/creacc/CreaccController.java
@@ -66,9 +66,6 @@ public class CreaccController {
         if (result.isCapacityFailure()) {
             return HttpStatus.CONFLICT;
         }
-        if (result.isTransientFailure()) {
-            return HttpStatus.SERVICE_UNAVAILABLE;
-        }
         return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 


### PR DESCRIPTION
Closes #14.

## Why

Issue #14 asked us to decide whether `CreaccResult.isTransientFailure()`
(and the matching `503 SERVICE_UNAVAILABLE` mapping in
`CreaccController#failureStatus`) is dead code now that the COBOL
ENQ/DEQ around the account-counter row has been replaced with
`SELECT ... FOR UPDATE` on `control`.

Audit of every fail-code emission in CREACC:

- `CreaccService.create(...)` emits `"A"` (validation), `"1"` (customer
  not found), `"9"` (account-count fetch failed), and `"8"` (capacity
  reached).
- `CreaccRepository` only emits `"7"` via `rollbackFailure(...)` for an
  account-insert rollback.
- `CrdbRetry` retries `40001` serialization failures, and any
  surviving `DataAccessException` is wrapped into a
  `CbsaAbendException` and surfaced as `500/UNEX` via the global
  handler.

Nothing in the CREACC path produces fail codes `"3"` or `"5"`, so the
`isTransientFailure()` predicate and its `503` mapping are unreachable.

## What

- Drop `TRANSIENT_FAIL_CODES` and the `isTransientFailure()` predicate
  from `CreaccResult`.
- Drop the `if (result.isTransientFailure()) ... 503` branch from
  `CreaccController#failureStatus`.

If transient counter-lock errors ever do need a domain-level fail
code in the future, they can be reintroduced as a fresh predicate
plus an explicit emission site, rather than being kept as silently
dead code.

## Tests

No behaviour change for any reachable code path. `./mvnw verify`:
205/205 green locally (no test-suite changes required).

augment review
